### PR TITLE
merges #397

### DIFF
--- a/src/Controller/Component/JsonComponent.php
+++ b/src/Controller/Component/JsonComponent.php
@@ -36,7 +36,10 @@ class JsonComponent extends Component
         $body = $response->getBody();
 
         $this->response = $this->response->withStatus($response->getStatusCode());
-        if ($response->isOk()) {
+
+        // \Cake\Http\Client\Messsage には`200`～`202`の定義しかないため、
+        // \Cake\Http\Client\Responseのこのメソッドは`204`をOKとしていない
+        if ($response->isOk() || $response->getStatusCode() === 204) {
             return json_decode($body, $assoc);
         }
 


### PR DESCRIPTION
### 原因

- \Cake\Http\Client\Responseの`isOK()`関数が`204`を対象に含めていないため

### 対応内容

- レスポンスのステータスコードが`204`の場合も成功とみなすよう修正

