### PR TITLE
fixes #391 入段日を編集可能に

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -188,8 +188,7 @@ Type::build('timestamp')
     ->useImmutable();
 
 // デフォルトのバリデータを変更
-Validator::addDefaultProvider('default',
-    new RulesProvider('Gotea\Validation\MyValidation'));
+Validator::addDefaultProvider('default', new RulesProvider('Gotea\Validation\MyValidation'));
 
 /*
 * Custom Inflector rules, can be set to correctly pluralize or singularize

--- a/config/routes.php
+++ b/config/routes.php
@@ -70,10 +70,16 @@ Router::scope('/', function (RouteBuilder $routes) {
     });
 
     $routes->scope('/players', function (RouteBuilder $routes) {
-        $routes->post('/:id/scores', ['controller' => 'TitleScores', 'action' => 'searchByPlayer'],
-            'find_player_scores')->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->post('/:id/ranks', ['controller' => 'PlayerRanks', 'action' => 'create'],
-            'create_ranks')->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        $routes->post(
+            '/:id/scores',
+            ['controller' => 'TitleScores', 'action' => 'searchByPlayer'],
+            'find_player_scores'
+        )->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        $routes->post(
+            '/:id/ranks',
+            ['controller' => 'PlayerRanks', 'action' => 'create'],
+            'create_ranks'
+        )->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
     });
 
     $routes->scope('/ranks', ['controller' => 'PlayerRanks'], function (RouteBuilder $routes) {

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -40,7 +40,8 @@
     .system-name {
         width: 15%;
         min-width: 200px;
-        font-size: 130%;
+        color: #e2d14b;
+        font-size: 180%;
         font-weight: bold;
     }
     .page-title {
@@ -152,6 +153,10 @@
     .year {
         width: 4rem;
         text-align: right;
+    }
+
+    .joined {
+        width: 80px;
     }
 
     .remarks {

--- a/src/Controller/PlayersController.php
+++ b/src/Controller/PlayersController.php
@@ -123,24 +123,29 @@ class PlayersController extends AppController
     {
         // エンティティ取得 or 生成
         $player = $this->Players->findOrNew(['id' => $id]);
-
-        // 保存
         $this->Players->patchEntity($player, $this->request->getParsedBody());
+
+        // 失敗
         if (!$this->Players->save($player)) {
             $this->_writeToSession('player', $player)->_setErrors($player->errors());
-        } else {
-            $this->_setMessages(__('[{0}: {1}] を保存しました。', $player->id, $player->name));
 
-            // 連続作成の場合は新規登録画面へリダイレクト
-            if (!$id && $this->request->getData('is_continue')) {
-                return $this->redirect([
-                    'action' => 'new',
-                    '?' => ['country_id' => $player->country_id],
-                ]);
-            }
+            return $this->setAction(($player->id ? 'view' : 'new'), $player->id);
         }
 
-        return $this->setAction(($player->id ? 'view' : 'new'), $player->id);
+        // 成功
+        $this->_setMessages(__('[{0}: {1}] を保存しました。', $player->id, $player->name));
+        // 連続作成の場合は新規登録画面へリダイレクト
+        if (!$id && $this->request->getData('is_continue')) {
+            return $this->redirect([
+                '_name' => 'new_player',
+                '?' => ['country_id' => $player->country_id],
+            ]);
+        }
+
+        return $this->redirect([
+            '_name' => ($player->id ? 'view_player' : 'new_player'),
+            $player->id,
+        ]);
     }
 
     /**

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -34,7 +34,7 @@ class UsersController extends AppController
             return $this->redirect($this->Auth->redirectUrl());
         }
 
-        return $this->set('form', new LoginForm)->_renderWith('ログイン');
+        return $this->set('form', new LoginForm)->render();
     }
 
     /**

--- a/src/Model/Entity/AppEntity.php
+++ b/src/Model/Entity/AppEntity.php
@@ -21,16 +21,16 @@ class AppEntity extends Entity
     /**
      * {@inheritDoc}
      */
-    public function &get($property)
-    {
-        $value = parent::get($property);
-        // 配列ならCollectionに変換
-        if (is_array($value)) {
-            $value = collection($value);
-        }
+    // public function &get($property)
+    // {
+    //     $value = parent::get($property);
+    //     // 配列ならCollectionに変換
+    //     if (is_array($value)) {
+    //         $value = collection($value);
+    //     }
 
-        return $value;
-    }
+    //     return $value;
+    // }
 
     /**
      * バリデーションエラー一覧を取得します。

--- a/src/Model/Entity/Player.php
+++ b/src/Model/Entity/Player.php
@@ -12,6 +12,42 @@ use Cake\Routing\Router;
 class Player extends AppEntity
 {
     /**
+     * 入力フォーム用の入段日を取得します。
+     *
+     * @return array 入力フォーム用の入段日
+     */
+    protected function _getInputJoined()
+    {
+        $value = $this->joined;
+        $res = [];
+        if (strlen($value) >= 4) {
+            $res['year'] = substr($value, 0, 4);
+        }
+        if (strlen($value) >= 6) {
+            $res['month'] = substr($value, 4, 2);
+        }
+        if (strlen($value) >= 8) {
+            $res['day'] = substr($value, 6, 2);
+        }
+
+        return $res;
+    }
+
+    /**
+     * 入段日を日付フォーマットに変更して取得します。
+     *
+     * @return array 入段日
+     */
+    protected function _getFormatJoined()
+    {
+        $joined = collection($this->input_joined)->reject(function ($item) {
+            return $item === '' || $item === null;
+        })->toArray();
+
+        return implode('/', $joined);
+    }
+
+    /**
      * 年齢を取得します。
      *
      * @return int|null 年齢
@@ -115,9 +151,20 @@ class Player extends AppEntity
      * @param mixed $joined 設定値
      * @return string
      */
-    protected function _setJoined($joined)
+    protected function _setInputJoined($joined)
     {
-        return str_replace(['-', '/'], '', $joined);
+        $value = '';
+        if (isset($joined['year'])) {
+            $value .= $joined['year'];
+        }
+        if (!empty($joined['month'])) {
+            $value .= $joined['month'];
+        }
+        if (!empty($joined['day']) && strlen($value) === 6) {
+            $value .= $joined['day'];
+        }
+
+        return $this->joined = $value;
     }
 
     /**

--- a/src/Model/Entity/Title.php
+++ b/src/Model/Entity/Title.php
@@ -38,7 +38,7 @@ class Title extends AppEntity
      */
     protected function _getNowRetention()
     {
-        return $this->retention_histories->filter(function ($item, $key) {
+        return collection($this->retention_histories)->filter(function ($item, $key) {
             return $item->holding === $this->holding;
         })->first();
     }
@@ -50,7 +50,7 @@ class Title extends AppEntity
      */
     protected function _getHistories()
     {
-        return $this->retention_histories->filter(function ($item, $key) {
+        return collection($this->retention_histories)->filter(function ($item, $key) {
             return $item->holding < $this->holding;
         });
     }

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -9,7 +9,7 @@
         <?= $this->Html->charset() ?>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>
-            <?='棋士情報管理システム - '.h($cakeDescription ?? '') ?>
+            <?='Gotea - '.h($cakeDescription ?? '') ?>
         </title>
         <?= $this->Html->meta('icon') ?>
 
@@ -23,9 +23,9 @@
             <!-- ヘッダー -->
             <?php if (!isset($isDialog)) : ?>
             <header class="header">
-                <div class="system-name">棋士情報管理システム</div>
+                <div class="system-name"><?= isset($username) ? 'Gotea' : '' ?></div>
                 <!-- 見出し -->
-                <h1 class="page-title"><?=h($cakeDescription ?? '')?></h1>
+                <h1 class="page-title"><?=h($cakeDescription ?? 'Gotea')?></h1>
                 <div class="other">
                     <?php if (isset($username)) : ?>
                         <span class="username">ユーザ：<?=h($username)?></span>

--- a/src/Template/Players/index.ctp
+++ b/src/Template/Players/index.ctp
@@ -124,7 +124,7 @@
                         <?=h($player->name_english); ?>
                     </span>
                     <span class="enrollment">
-                        <?=$this->Date->formatJoinDelimiterValue($player->joined, '/'); ?>
+                        <?= $player->format_joined ?>
                     </span>
                     <span class="country">
                         <?=h($player->country->name); ?>

--- a/src/Template/Players/view.ctp
+++ b/src/Template/Players/view.ctp
@@ -107,16 +107,28 @@
                         <div class="box">
                             <div class="label-row">入段日</div>
                             <div class="input-row">
-                                <?php
-                                if (!$player->id) {
-                                    echo $this->Form->text('joined', [
-                                        'class' => 'datepicker'
-                                    ]);
-                                } else {
-                                    echo $this->Date->formatJpValue($player->joined);
-                                    echo $this->Form->hidden('joined');
-                                }
-                                ?>
+                                <?= $this->Form->date('input_joined', [
+                                    'empty' => [
+                                        'year' => false,
+                                        'month' => ['' => '-'],
+                                        'day' => ['' => '-'],
+                                    ],
+                                    'year' => [
+                                        'start' => '1920',
+                                        'end' => date('Y'),
+                                        'class' => 'joined',
+                                        'suffix' => '年',
+                                    ],
+                                    'month' => [
+                                        'class' => 'joined',
+                                        'suffix' => '月',
+                                    ],
+                                    'day' => [
+                                        'class' => 'joined',
+                                        'suffix' => '日',
+                                    ],
+                                    'monthNames' => false,
+                                ]); ?>
                             </div>
                         </div>
                     </li>

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Gotea\View\Widget;
+
+use Cake\View\Widget\DateTimeWidget as BaseDateTimeWidget;
+
+/**
+ * `datatime`のカスタムウィジェット
+ */
+class DateTimeWidget extends BaseDateTimeWidget
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function _yearSelect($options, $context)
+    {
+        $options += [
+            'name' => '',
+            'val' => null,
+            'start' => date('Y', strtotime('-5 years')),
+            'end' => date('Y', strtotime('+5 years')),
+            'order' => 'desc',
+            'templateVars' => [],
+            'options' => []
+        ];
+
+        if (!empty($options['val'])) {
+            $options['start'] = min($options['val'], $options['start']);
+            $options['end'] = max($options['val'], $options['end']);
+        }
+        if (empty($options['options'])) {
+            $options['options'] = $this->_generateNumbers($options['start'], $options['end'], $options);
+        }
+        if ($options['order'] === 'desc') {
+            $options['options'] = array_reverse($options['options'], true);
+        }
+        unset($options['start'], $options['end'], $options['order']);
+
+        return $this->_select->render($options, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _generateNumbers($start, $end, $options = [])
+    {
+        $numbers = parent::_generateNumbers($start, $end, $options);
+
+        // サフィックスがあればテキストに付与
+        if (($suffix = $options['suffix'] ?? '')) {
+            foreach ($numbers as $key => $value) {
+                $numbers[$key] = $value . $suffix;
+            }
+        }
+
+        return $numbers;
+    }
+}

--- a/tests/TestCase/Model/Table/PlayersTableTest.php
+++ b/tests/TestCase/Model/Table/PlayersTableTest.php
@@ -105,8 +105,8 @@ class PlayersTableTest extends TestCase
         $this->assertNotNull($player);
         $this->assertNotNull($player->country);
         $this->assertNotNull($player->rank);
-        $this->assertGreaterThan(0, iterator_count($player->player_ranks));
-        $this->assertGreaterThan(0, iterator_count($player->title_score_details));
+        $this->assertGreaterThan(0, count($player->player_ranks));
+        $this->assertGreaterThan(0, count($player->title_score_details));
     }
 
     /**


### PR DESCRIPTION
### 概要

- 棋士詳細の入段日を棋士登録後も編集可能にする

### 対応内容

- 入力フィールドは「年・月・日」をプルダウンで保持
- アクセサ・ミューテタに変換処理追加
