### PR TITLE
merges #408

### DIFF
--- a/resources/assets/js/components/ranking/Header.vue
+++ b/resources/assets/js/components/ranking/Header.vue
@@ -1,7 +1,7 @@
 <template>
     <ul class="search-header">
         <li class="search-row">
-            <label class="ranking_label">抽出対象：</label>
+            <label class="search-row_label ranking_label">抽出対象</label>
             <select v-model="select.year" name="year" class="ranking_year" @change="changeValue($event)">
                 <option v-for="(year, idx) in years" :key="idx" :value="year.value" v-text="year.text"></option>
             </select>
@@ -13,15 +13,15 @@
             </select>
         </li>
         <li class="search-row">
-            <label class="ranking_label">対局日：</label>
+            <label class="search-row_label ranking_label">対局日</label>
             <input type="text" name="from" class="ranking_date datepicker"
                 v-model="select.from" @change="changeValue($event)" :disabled="!useInputDate()">
-            <span>～</span>
+            <span class="ranking_date-duration">～</span>
             <input type="text" name="to" class="ranking_date datepicker"
                 v-model="select.to" @change="changeValue($event)" :disabled="!useInputDate()">
         </li>
         <li class="search-row">
-            <label class="ranking_label">最終更新日：</label>
+            <label class="search-row_label ranking_label">最終更新日</label>
             <span class="lastUpdate" v-text="lastUpdate"></span>
             <div class="button-wrap">
                 <button type="button" @click="clearDate()">日付をクリア</button>
@@ -73,7 +73,7 @@ export default {
         },
     },
     mounted() {
-    // 所属国
+        // 所属国
         Promise.all([
             this.$http.get('/api/countries'),
             this.$http.get('/api/years'),

--- a/resources/assets/js/components/ranking/Items.vue
+++ b/resources/assets/js/components/ranking/Items.vue
@@ -2,27 +2,27 @@
     <div class="search-results">
         <ul class="table-header">
             <li class="table-row">
-                <span class="no">No.</span>
-                <span class="player">棋士名</span>
-                <span class="point">勝</span>
-                <span class="point">敗</span>
-                <span class="point">分</span>
-                <span class="percent">勝率</span>
+                <span class="table-column_no">No.</span>
+                <span class="table-column_player">棋士名</span>
+                <span class="table-column_point">勝</span>
+                <span class="table-column_point">敗</span>
+                <span class="table-column_point">分</span>
+                <span class="table-column_percent">勝率</span>
             </li>
         </ul>
         <ul class="table-body" v-if="items.length">
             <li class="table-row" v-for="(item, idx) in items" :key="idx">
-                <span class="right no">
+                <span class="table-column_no">
                     <span v-text="getRank(idx, item)"></span>
                 </span>
-                <span class="left player">
+                <span class="table-column_player">
                     <a class="view-link" :class="getSexClass(item)" @click="select(item)"
                         v-text="item.name"></a>
                 </span>
-                <span class="point" v-text="item.win"></span>
-                <span class="point" v-text="item.lose"></span>
-                <span class="point" v-text="item.draw"></span>
-                <span class="percent" v-text="item.percentage"></span>
+                <span class="table-column_point" v-text="item.win"></span>
+                <span class="table-column_point" v-text="item.lose"></span>
+                <span class="table-column_point" v-text="item.draw"></span>
+                <span class="table-column_percent" v-text="item.percentage"></span>
             </li>
         </ul>
     </div>

--- a/resources/assets/js/components/ranks/Header.vue
+++ b/resources/assets/js/components/ranks/Header.vue
@@ -1,7 +1,7 @@
 <template>
     <ul class="search-header">
         <li class="search-row">
-            <label>対象国：</label>
+            <label class="search-row_label">対象国</label>
             <select class="country" v-model="select.country" @change="changeValue($event)">
                 <option v-for="(country, idx) in countries" :key="idx" :value="country.value" v-text="country.text"></option>
             </select>

--- a/resources/assets/js/components/ranks/Items.vue
+++ b/resources/assets/js/components/ranks/Items.vue
@@ -2,14 +2,14 @@
     <div class="search-results">
         <ul class="table-header">
             <li class="table-row">
-                <span class="rank">段位</span>
-                <span class="count">人数</span>
+                <span class="table-column_rank">段位</span>
+                <span class="table-column_count">人数</span>
             </li>
         </ul>
         <ul class="table-body" v-if="items.length">
             <li class="table-row" v-for="(item, idx) in items" :key="idx">
-                <span class="rank" v-text="item.name"></span>
-                <span class="count" v-text="count(item)"></span>
+                <span class="table-column_rank" v-text="item.name"></span>
+                <span class="table-column_count" v-text="count(item)"></span>
             </li>
         </ul>
     </div>

--- a/resources/assets/js/components/titles/AddHistory.vue
+++ b/resources/assets/js/components/titles/AddHistory.vue
@@ -1,5 +1,5 @@
 <template>
-    <li class="row">
+    <li class="detail-row">
         <input type="hidden" :value="historyId" name="id">
         <input type="hidden" v-model="teamTitle" name="is_team">
         <div class="box">
@@ -96,18 +96,18 @@ export default {
                 .then(res => {
                     const players = res.body.response.results;
                     switch (players.length) {
-                    case 0:
-                        this.$store.dispatch('openDialog', {
-                            messages: '検索結果が0件でした。',
-                            type: 'warning',
-                        });
-                        break;
-                    case 1:
-                        this.select(players[0]);
-                        break;
-                    default:
-                        this.players = players;
-                        break;
+                        case 0:
+                            this.$store.dispatch('openDialog', {
+                                messages: '検索結果が0件でした。',
+                                type: 'warning',
+                            });
+                            break;
+                        case 1:
+                            this.select(players[0]);
+                            break;
+                        default:
+                            this.players = players;
+                            break;
                     }
                 })
                 .catch(res => {

--- a/resources/assets/js/components/titles/Header.vue
+++ b/resources/assets/js/components/titles/Header.vue
@@ -2,13 +2,13 @@
     <ul class="search-header">
         <li class="search-row">
             <div>
-                <label>対象国：</label>
+                <label class="search-row_label">対象国</label>
                 <select class="titles-country" v-model="select.country" @change="changeValue($event)">
                     <option v-for="(country, idx) in countries" :key="idx" :value="country.value" v-text="country.text"></option>
                 </select>
             </div>
             <div>
-                <label>終了棋戦：</label>
+                <label class="search-row_label">終了棋戦</label>
                 <select class="titles-closed" v-model="select.type" @change="changeValue($event)">
                     <option v-for="(type, idx) in types" :key="idx" :value="type.value" v-text="type.text"></option>
                 </select>

--- a/resources/assets/js/components/titles/Index.vue
+++ b/resources/assets/js/components/titles/Index.vue
@@ -4,16 +4,16 @@
         <div class="search-results">
             <ul class="table-header">
                 <li class="table-row">
-                    <span class="table-column name">タイトル名</span>
-                    <span class="table-column name">タイトル名（英語）</span>
-                    <span class="table-column holding">期</span>
-                    <span class="table-column winner">優勝者</span>
-                    <span class="table-column order">並び順</span>
-                    <span class="table-column team">団体</span>
-                    <span class="table-column filename">ファイル名</span>
-                    <span class="table-column modified">修正日</span>
-                    <span class="table-column closed">終了<br>棋戦</span>
-                    <span class="table-column open-detail">詳細</span>
+                    <span class="table-column table-column_name">タイトル名</span>
+                    <span class="table-column table-column_name">タイトル名（英語）</span>
+                    <span class="table-column table-column_holding">期</span>
+                    <span class="table-column table-column_winner">優勝者</span>
+                    <span class="table-column table-column_order">並び順</span>
+                    <span class="table-column table-column_team">団体</span>
+                    <span class="table-column table-column_filename">ファイル名</span>
+                    <span class="table-column table-column_modified">修正日</span>
+                    <span class="table-column table-column_closed">終了<br>棋戦</span>
+                    <span class="table-column table-column_open-detail">詳細</span>
                 </li>
             </ul>
             <ul class="table-body" v-if="items.length">

--- a/resources/assets/js/components/titles/Item.vue
+++ b/resources/assets/js/components/titles/Item.vue
@@ -1,31 +1,31 @@
 <template>
     <li class="table-row" :class="rowClass">
-        <span class="table-column name">
+        <span class="table-column table-column_name">
             <input type="text" @change="save" v-model="item.name">
         </span>
-        <span class="table-column name">
+        <span class="table-column table-column_name">
             <input type="text" @change="save" v-model="item.nameEnglish">
         </span>
-        <span class="table-column holding">
-            <input type="text" class="input-holding" @change="save" v-model="item.holding">
+        <span class="table-column table-column_holding">
+            <input type="text" class="table-column_holding-input" @change="save" v-model="item.holding">
         </span>
-        <span class="table-column winner" v-text="winnerName"></span>
-        <span class="table-column order">
-            <input type="text" class="input-sortorder" @change="save" v-model="item.sortOrder">
+        <span class="table-column table-column_winner" v-text="winnerName"></span>
+        <span class="table-column table-column_order">
+            <input type="text" class="table-column_order-input" @change="save" v-model="item.sortOrder">
         </span>
-        <span class="table-column team">
+        <span class="table-column table-column_team">
             <input type="checkbox" @change="save" v-model="item.isTeam">
         </span>
-        <span class="table-column filename">
+        <span class="table-column table-column_filename">
             <input type="text" @change="save" v-model="item.htmlFileName">
         </span>
-        <span class="table-column modified">
-            <input type="text" class="datepicker input-modified" @change="saveDatepicker($event)" v-model="item.htmlFileModified">
+        <span class="table-column table-column_modified">
+            <input type="text" class="datepicker table-column_modified-input" @change="saveDatepicker($event)" v-model="item.htmlFileModified">
         </span>
-        <span class="table-column closed">
+        <span class="table-column table-column_closed">
             <input type="checkbox" @change="save" v-model="item.isClosed" :disabled="!isSaved()">
         </span>
-        <span class="table-column open-detail">
+        <span class="table-column table-column_open-detail">
             <a class="view-link" @click="select()" v-text="label"></a>
         </span>
     </li>

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,15 +1,7 @@
 @import 'module/_variables.scss';
 @import 'module/_normalize.scss';
 @import 'module/_mixin.scss';
-
-%row {
-    display: flex;
-    margin: 0.2rem auto;
-    padding: 0.2rem;
-    align-items: center;
-    justify-content: flex-start;
-    min-height: #{$minRowHeight};
-}
+@import 'module/_view.scss';
 
 /* -------------------------------------------
    共通レイアウト
@@ -17,12 +9,12 @@
 .nav {
     margin: 0;
     padding: 0;
-    background-color: #848fa3;
+    background-color: $c_nav;
     overflow-y: auto;
 }
 
 .nav-menu {
-    @include navi(#848fa3);
+    @include navi($c_nav);
     display: flex;
     margin: 0;
     padding: 0;
@@ -72,101 +64,6 @@
     height: 100%;
 }
 
-.button-row {
-    display: flex;
-    margin: .5em auto;
-    align-items: center;
-    justify-content: center;
-}
-
-.category-row {
-    @extend %row;
-    margin: 0 auto;
-    height: 2.5rem;
-    text-indent: 0.5rem;
-    font-size: 1.2rem;
-    font-weight: bold;
-    background-color: #def;
-}
-
-.genre-row {
-    @extend %row;
-    height: 2.3rem;
-    text-indent: 0.6rem;
-    font-size: 1.1rem;
-    font-weight: bold;
-    background-color: #efd;
-}
-
-.label-row {
-    @extend %row;
-    margin: 0 auto;
-    min-height: 2.2rem;
-    text-indent: 0.7rem;
-    background-color: #fed;
-    font-weight: bold;
-}
-
-.input-row {
-    @extend %row;
-    margin: 0;
-    padding: .5rem .7rem;
-    min-height: 3rem;
-
-    &-label {
-        margin-right: 5px;
-        margin-left: 15px;
-    }
-
-    select {
-        width: 100%;
-    }
-
-    .inner-column {
-        margin: auto 5px;
-    }
-
-    .button-wrap {
-        margin-left: auto;
-    }
-
-    .checkbox-label {
-        margin-right: 10px;
-        margin-left: 5px;
-    }
-
-    .name {
-        width: 160px;
-    }
-
-    .point {
-        width: 2.5rem;
-        text-align: right;
-    }
-
-    .holding {
-        width: 3rem;
-        text-align: right;
-    }
-
-    .datepicker {
-        width: 9rem;
-    }
-
-    .year {
-        width: 4rem;
-        text-align: right;
-    }
-
-    .joined {
-        width: 80px;
-    }
-
-    .remarks {
-        width: 100%;
-    }
-}
-
 .main-form {
     width: 100%;
     height: 100%;
@@ -203,7 +100,7 @@
     border-top: none;
     border-radius: 0 0 5px 5px;
     background-color: $c_white;
-    max-height: 250px;
+    max-height: 300px;
     overflow-y: auto;
 
     * {
@@ -235,110 +132,15 @@
     border-radius: 0.4rem;
 }
 
-.search-row {
-    label {
-        margin: 0 5px 0 10px;
-        font-weight: normal;
-    }
-
-    .button-wrap {
-        margin-right: 0;
-    }
-
-    .year, .country, .sex, .rank {
-        width: 6em;
-    }
-    .organization, .excluded {
-        width: 10em;
-    }
-}
-
-/* -------------------------------------------
-   詳細表示エリア
- ------------------------------------------- */
-.detail-dialog {
-    width: 100%;
-    height: 100%;
-    .tabs {
-        @include not-liststyle();
-        display: flex;
-        margin: 0;
-        height: 30px;
-        .tab {
-            padding: 0.4rem 1rem;
-            font-size: 1rem;
-            color: $c_white;
-            background-color: $c_black;
-            border: 0.1rem solid $c_black;
-            border-bottom: none;
-            border-radius: 0.5rem 0.5rem 0 0;
-            transition: font-weight .3s, color .3s, background-color .3s;
-            &.selectTab {
-                font-weight: bold;
-                color: $c_black;
-                background-color: #9ff;
-            }
-            &:not(.selectTab):hover {
-                background-color: lighten($c_black, 25%);
-                cursor: pointer;
-            }
-        }
-    }
-    .detail {
-        height: calc(100% - 30px);
-        overflow-y: auto;
-        border: 0.1rem solid $c_black;
-        background-color: $c_white;
-
-        .tab-contents {
-            @include fade(.5, 'not-select');
-        }
-
-        .boxes {
-            @include not-liststyle();
-            margin: 0;
-            .row {
-                margin: 0 auto;
-                .box {
-                    flex-grow: 1;
-                }
-                .box2 {
-                    flex-grow: 2;
-                }
-            }
-        }
-    }
-}
-
-.rank-form {
-    width: 100%;
-
-    .rank-input-box {
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-        width: 100%;
-    }
-
-    .rank-input {
-        width: 200px;
-
-        &:not(:first-child) {
-            margin-left: 10px;
-        }
-
-        &.checkbox-wrap {
-            margin-left: auto;
-            text-align: right;
-        }
-    }
+.search-row_label {
+    padding: 0 5px 0 15px;
+    font-weight: normal;
 }
 
 /* -------------------------------------------
    勝敗ランキング画面
  ------------------------------------------- */
 .ranking {
-    margin-top: 0;
     width: 30rem;
 
     .search-header {
@@ -347,25 +149,35 @@
 
     &_label {
         width: 90px;
+        text-align: right;
     }
+
     &_year, &_country, &_limit {
         margin-right: .4rem;
         width: 100px;
     }
+
     &_date {
         width: 110px;
+        &-duration {
+            margin: auto .4rem;
+        }
     }
 
     .search-results {
         height: calc(100% - #{$h_ranking_header} - 1rem); /* content - .search-header and margin */
+    }
 
-        .no, .percent {
+    .table-column {
+        &_no, &_percent {
             width: 13%;
         }
-        .player {
+
+        &_player {
             width: 40%;
         }
-        .point {
+
+        &_point {
             width: 10%;
         }
     }
@@ -389,24 +201,32 @@
             width: 8em;
         }
     }
+
     .search-results {
         &.modal {
             height: calc(100% - 3rem);
         }
-        .selected {
-            color: #04d;
-            font-weight: bold;
-        }
-        .id {
+    }
+
+    .table-column {
+        &_id {
             width: 6%;
         }
-        .country, .date {
+
+        &_country, &_date {
             width: 12%;
         }
-        .name {
+
+        &_name {
             width: 25%;
+
+            .selected {
+                color: #04d;
+                font-weight: bold;
+            }
         }
-        .operation {
+
+        &_operation {
             display: flex;
             width: 20%;
             justify-content: center;
@@ -421,11 +241,6 @@
    棋士情報検索
  ------------------------------------------- */
 .players {
-    .table-row {
-        &.retired {
-            background-color: $c_gray;
-        }
-    }
     .search-header {
         height: $h_players_header;
 
@@ -444,7 +259,38 @@
     }
     .search-results {
         height: calc(100% - #{$h_players_header} - 10px); /* content - .search-header and padding */
-        .score {
+    }
+
+    .table-row-retired {
+        background-color: $c_gray;
+    }
+
+    .table-column {
+        &_id {
+            width: 6%;
+        }
+
+        &_name {
+            width: 20%;
+        }
+
+        &_country {
+            width: 6%;
+        }
+
+        &_enrollment {
+            width: 10%;
+        }
+
+        &_rank, &_sex {
+            width: 5%;
+        }
+
+        &_organization {
+            width: 8%;
+        }
+
+        &_score {
             padding: 0;
             width: 9%;
             &-point {
@@ -453,31 +299,7 @@
             }
         }
 
-        .id {
-            width: 6%;
-        }
-
-        .name {
-            width: 20%;
-        }
-
-        .country {
-            width: 6%;
-        }
-
-        .enrollment {
-            width: 10%;
-        }
-
-        .rank, .sex {
-            width: 5%;
-        }
-
-        .organization {
-            width: 8%;
-        }
-
-        .point {
+        &_point {
             width: 3%;
         }
     }
@@ -487,13 +309,6 @@
    タイトル情報検索
  ------------------------------------------- */
 .titles {
-    .table-column {
-        padding: 0 5px;
-        & > * {
-            max-width: 100%;
-        }
-    }
-
     &-country {
         width: 90px;
     }
@@ -505,42 +320,43 @@
         background-color: $c_gray;
     }
 
-    .name {
-        width: 20%;
-    }
+    .table-column {
+        padding: 0 5px;
 
-    .winner {
-        width: 15%;
-    }
+        &_name {
+            width: 20%;
+        }
 
-    .holding, .order {
-        width: 5%;
-    }
+        &_winner {
+            width: 15%;
+        }
 
-    .team, .closed {
-        width: 5%;
-        text-align: center;
-    }
+        &_holding, &_order {
+            width: 5%;
+            &-input {
+                text-align: right;
+            }
+        }
 
-    .filename {
-        width: 8%;
-    }
+        &_team, &_closed {
+            width: 5%;
+            text-align: center;
+        }
 
-    .modified {
-        width: 10%;
-    }
+        &_filename {
+            width: 8%;
+        }
 
-    .open-detail {
-        padding-left: 10px;
-    }
+        &_modified {
+            width: 10%;
+            &-input {
+                text-align: center;
+            }
+        }
 
-    .input-holding,
-    .input-sortorder {
-        text-align: right;
-    }
-
-    .input-modified {
-        text-align: center;
+        &_open-detail {
+            padding-left: 10px;
+        }
     }
 }
 
@@ -569,11 +385,12 @@
  ------------------------------------------- */
 .categories {
     width: 15em;
-    .search-results {
-        .rank {
+    .table-column {
+        &_rank {
             width: 40%;
         }
-        .count {
+
+        &_count {
             width: 60%;
         }
     }

--- a/resources/assets/sass/module/_mixin.scss
+++ b/resources/assets/sass/module/_mixin.scss
@@ -17,6 +17,7 @@
 }
 
 @mixin not-liststyle() {
+    margin: 0;
     padding: 0;
     list-style: none;
 }

--- a/resources/assets/sass/module/_normalize.scss
+++ b/resources/assets/sass/module/_normalize.scss
@@ -40,6 +40,7 @@ strong {
 }
 
 input, textarea, select {
+    max-width: 100%;
     &:focus {
         background-color: #ffc;
     }

--- a/resources/assets/sass/module/_variables.scss
+++ b/resources/assets/sass/module/_variables.scss
@@ -7,6 +7,8 @@ $c_red: #f00;
 $c_blue: #00f;
 $c_gray: #ccc;
 
+$c_nav: #534e4e;
+
 // ナビゲーション
 $w_nav: 240px;
 

--- a/resources/assets/sass/module/_view.scss
+++ b/resources/assets/sass/module/_view.scss
@@ -1,0 +1,185 @@
+/* -------------------------------------------
+   詳細表示エリア
+ ------------------------------------------- */
+.detail-dialog {
+    width: 100%;
+    height: 100%;
+    .tabs {
+        @include not-liststyle();
+        display: flex;
+        height: 30px;
+        .tab {
+            padding: 0.4rem 1rem;
+            font-size: 1rem;
+            color: $c_white;
+            background-color: $c_black;
+            border: 0.1rem solid $c_black;
+            border-bottom: none;
+            border-radius: 0.5rem 0.5rem 0 0;
+            transition: font-weight .3s, color .3s, background-color .3s;
+            &.selectTab {
+                font-weight: bold;
+                color: $c_black;
+                background-color: #9ff;
+            }
+            &:not(.selectTab):hover {
+                background-color: lighten($c_black, 25%);
+                cursor: pointer;
+            }
+        }
+    }
+    .detail {
+        height: calc(100% - 30px);
+        overflow-y: auto;
+        border: 0.1rem solid $c_black;
+        background-color: $c_white;
+
+        .tab-contents {
+            @include fade(.5, 'not-select');
+        }
+
+        .boxes {
+            @include not-liststyle();
+        }
+    }
+}
+
+%row {
+    display: flex;
+    padding: 0.2rem;
+    align-items: center;
+    justify-content: flex-start;
+    min-height: #{$minRowHeight};
+}
+
+.detail-row {
+    @extend %row;
+    margin: 0 auto;
+    padding: 0;
+    align-items: flex-start;
+    .box {
+        flex-grow: 1;
+    }
+    .box2 {
+        flex-grow: 2;
+    }
+}
+
+.button-row {
+    display: flex;
+    margin: .5em auto;
+    align-items: center;
+    justify-content: center;
+}
+
+.category-row {
+    @extend %row;
+    margin: 0 auto;
+    height: 2.5rem;
+    text-indent: 0.5rem;
+    font-size: 1.2rem;
+    font-weight: bold;
+    background-color: #def;
+}
+
+.genre-row {
+    @extend %row;
+    height: 2.3rem;
+    text-indent: 0.6rem;
+    font-size: 1.1rem;
+    font-weight: bold;
+    background-color: #efd;
+}
+
+.label-row {
+    @extend %row;
+    margin: 0 auto;
+    min-height: 2.2rem;
+    text-indent: 0.7rem;
+    background-color: #fed;
+    font-weight: bold;
+}
+
+.input-row {
+    @extend %row;
+    margin: 0;
+    padding: .5rem .7rem;
+    min-height: 3rem;
+
+    &-label {
+        margin-right: 5px;
+        margin-left: 15px;
+    }
+
+    select {
+        width: 100%;
+    }
+
+    .inner-column {
+        margin: auto 5px;
+    }
+
+    .button-wrap {
+        margin-left: auto;
+    }
+
+    .checkbox-label {
+        margin-right: 10px;
+        margin-left: 5px;
+    }
+
+    .name {
+        width: 160px;
+    }
+
+    .point {
+        width: 2.5rem;
+        text-align: right;
+    }
+
+    .holding {
+        width: 3rem;
+        text-align: right;
+    }
+
+    .datepicker {
+        width: 9rem;
+    }
+
+    .year {
+        width: 4rem;
+        text-align: right;
+    }
+
+    .joined {
+        width: 80px;
+    }
+
+    .remarks {
+        width: 100%;
+    }
+}
+
+.rank-form {
+    width: 100%;
+
+    .rank-input-box {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: 100%;
+    }
+
+    .rank-input {
+        width: 200px;
+
+        &:not(:first-child) {
+            margin-left: 10px;
+        }
+
+        &.checkbox-wrap {
+            margin-left: auto;
+            text-align: right;
+        }
+    }
+}

--- a/src/Template/NativeQuery/index.ctp
+++ b/src/Template/NativeQuery/index.ctp
@@ -1,6 +1,5 @@
 <section class="update-score">
     <?=$this->Form->create(null, [
-        'id' => 'mainForm',
         'class' => 'main-form',
         'url' => ['_name' => 'execute_queries'],
         'templates' => [

--- a/src/Template/Players/index.ctp
+++ b/src/Template/Players/index.ctp
@@ -1,6 +1,5 @@
 <section class="players">
     <?=$this->Form->create($form, [
-        'id' => 'mainForm',
         'class' => 'main-form',
         'url' => ['_name' => 'find_players'],
         'templates' => [
@@ -12,7 +11,7 @@
         <ul class="search-header">
             <li class="search-row">
                 <div>
-                    <label>所属国：</label>
+                    <label class="search-row_label">所属国：</label>
                     <?= $this->cell('Countries', ['hasTitle' => true,
                         'customOptions' => [
                             '@change' => 'changeCountry($event)',
@@ -20,19 +19,19 @@
                     ])->render() ?>
                 </div>
                 <div>
-                    <label>所属組織：</label>
+                    <label class="search-row_label">所属組織：</label>
                     <?= $this->cell('Organizations', ['empty' => true])->render() ?>
                 </div>
                 <div>
-                    <label>段位：</label>
+                    <label class="search-row_label">段位：</label>
                     <?= $this->cell('Ranks', ['empty' => true])->render() ?>
                 </div>
                 <div>
-                    <label>性別：</label>
+                    <label class="search-row_label">性別：</label>
                     <?= $this->MyForm->sexes(['class' => 'sex', 'empty' => true]) ?>
                 </div>
                 <div>
-                    <label>入段年：</label>
+                    <label class="search-row_label">入段年：</label>
                     <?=$this->Form->number('joined_from', ['class' => 'joined', 'maxlength' => 4])?>
                     ～
                     <?=$this->Form->number('joined_to', ['class' => 'joined', 'maxlength' => 4])?>
@@ -40,30 +39,26 @@
             </li>
             <li class="search-row">
                 <div>
-                    <label>棋士名：</label>
+                    <label class="search-row_label">棋士名：</label>
                     <?=$this->Form->text('name', ['class' => 'name', 'maxlength' => 20])?>
                 </div>
                 <div>
-                    <label>（英語）：</label>
+                    <label class="search-row_label">（英語）：</label>
                     <?=$this->Form->text('name_english', ['class' => 'name', 'maxlength' => 40]);?>
                 </div>
                 <div>
-                    <label>（その他）：</label>
+                    <label class="search-row_label">（その他）：</label>
                     <?=$this->Form->text('name_other', ['class' => 'name', 'maxlength' => 20]);?>
                 </div>
             </li>
             <li class="search-row">
                 <div>
-                    <label>引退者：</label>
-                    <?=
-                        $this->MyForm->filters('is_retired', [
-                            'class' => 'excluded'
-                        ]);
-                    ?>
+                    <label class="search-row_label">引退者：</label>
+                    <?= $this->MyForm->filters('is_retired', ['class' => 'excluded']) ?>
                 </div>
-                <?php if (!empty($players) && $players->count() > 0) : ?>
+                <?php if (!empty($players)) : ?>
                 <div class="result-count">
-                    <?= $players->count().'件のレコードが該当しました。'?>
+                    <?= h("{$players->count()}件のレコードが該当しました。") ?>
                 </div>
                 <?php endif ?>
                 <div class="button-wrap">
@@ -78,25 +73,25 @@
         <div class="search-results">
             <ul class="players table-header">
                 <li class="table-row">
-                    <span class="id">ID</span>
-                    <span class="name">棋士名</span>
-                    <span class="name">棋士名（英語）</span>
-                    <span class="enrollment">入段日</span>
-                    <span class="country">所属国</span>
-                    <span class="organization">所属組織</span>
-                    <span class="rank">段位</span>
-                    <span class="sex">性別</span>
-                    <span class="score">
+                    <span class="table-column_id">ID</span>
+                    <span class="table-column_name">棋士名</span>
+                    <span class="table-column_name">棋士名（英語）</span>
+                    <span class="table-column_enrollment">入段日</span>
+                    <span class="table-column_country">所属国</span>
+                    <span class="table-column_organization">所属組織</span>
+                    <span class="table-column_rank">段位</span>
+                    <span class="table-column_sex">性別</span>
+                    <span class="table-column_score">
                         <div><?= date('Y') ?>年国内</div>
-                        <div class="score-point">
+                        <div class="table-column_score-point">
                             <span>勝</span>
                             <span>敗</span>
                             <span>分</span>
                         </div>
                     </span>
-                    <span class="score">
+                    <span class="table-column_score">
                         <div><?= date('Y') ?>年国際</div>
-                        <div class="score-point">
+                        <div class="table-column_score-point">
                             <span>勝</span>
                             <span>敗</span>
                             <span>分</span>
@@ -104,54 +99,54 @@
                     </span>
                 </li>
             </ul>
-            <?php if (!empty($players) && $players->count() > 0) : ?>
+            <?php if (!empty($players)) : ?>
             <ul class="players table-body">
                 <?php foreach ($players as $player) : ?>
-                <li class="table-row<?= ($player->is_retired ? ' retired' : '') ?>">
-                    <span class="id">
-                        <?=h($player->id)?>
+                <li class="table-row<?= ($player->is_retired ? ' table-row-retired' : '') ?>">
+                    <span class="table-column_id">
+                        <?= h($player->id) ?>
                     </span>
-                    <span class="name">
+                    <span class="table-column_name">
                         <a class="view-link<?= ($player->isFemale() ? ' female' : '') ?>"
                             @click="openModal('<?= $this->Url->build(['_name' => 'view_player', $player->id]) ?>')">
-                            <?=h($player->name)?>
+                            <?= h($player->name) ?>
                         </a>
                     </span>
-                    <span class="name">
-                        <?=h($player->name_english); ?>
+                    <span class="table-column_name">
+                        <?= h($player->name_english) ?>
                     </span>
-                    <span class="enrollment">
-                        <?= $player->format_joined ?>
+                    <span class="table-column_enrollment">
+                        <?= h($player->format_joined) ?>
                     </span>
-                    <span class="country">
-                        <?=h($player->country->name); ?>
+                    <span class="table-column_country">
+                        <?= h($player->country->name) ?>
                     </span>
-                    <span class="organization">
-                        <?=h($player->organization->name); ?>
+                    <span class="table-column_organization">
+                        <?= h($player->organization->name) ?>
                     </span>
-                    <span class="rank">
-                        <?=h($player->rank->name); ?>
+                    <span class="table-column_rank">
+                        <?= h($player->rank->name) ?>
                     </span>
-                    <span class="sex">
-                        <?=h($player->sex); ?>
+                    <span class="table-column_sex">
+                        <?= h($player->sex) ?>
                     </span>
-                    <span class="point">
-                        <?= h($player->win(null)); ?>
+                    <span class="table-column_point">
+                        <?= h($player->win(null)) ?>
                     </span>
-                    <span class="point">
-                        <?= h($player->lose(null)); ?>
+                    <span class="table-column_point">
+                        <?= h($player->lose(null)) ?>
                     </span>
-                    <span class="point">
-                        <?= h($player->draw(null)); ?>
+                    <span class="table-column_point">
+                        <?= h($player->draw(null)) ?>
                     </span>
-                    <span class="point">
-                        <?= h($player->win(null, true)); ?>
+                    <span class="table-column_point">
+                        <?= h($player->win(null, true)) ?>
                     </span>
-                    <span class="point">
-                        <?= h($player->lose(null, true)); ?>
+                    <span class="table-column_point">
+                        <?= h($player->lose(null, true)) ?>
                     </span>
-                    <span class="point">
-                        <?= h($player->draw(null, true)); ?>
+                    <span class="table-column_point">
+                        <?= h($player->draw(null, true)) ?>
                     </span>
                 </li>
                 <?php endforeach ?>

--- a/src/Template/Players/view.ctp
+++ b/src/Template/Players/view.ctp
@@ -16,10 +16,8 @@
         <!-- 棋士成績 -->
         <section data-contentname="player" class="tab-contents">
             <?=$this->Form->create($player, [
-                'id' => 'mainForm',
                 'class' => 'main-form',
                 'url' => $player->getSaveUrl(),
-                'novalidate' => 'novalidate',
                 'templates' => [
                     'inputContainer' => '{{content}}',
                     'textFormGroup' => '{{input}}',
@@ -30,7 +28,7 @@
                 <?=$this->Form->hidden('country_id')?>
                 <div class="category-row">棋士情報<?=($player->id ? '（ID：'.h($player->id).'）' : "")?></div>
                 <ul class="boxes">
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">所属国</div>
                             <div class="input-row">
@@ -65,7 +63,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">棋士名</div>
                             <div class="input-row">
@@ -92,7 +90,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">生年月日</div>
                             <div class="input-row">
@@ -132,7 +130,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">性別</div>
                             <div class="input-row">
@@ -158,7 +156,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">その他備考</div>
                             <div class="input-row">
@@ -184,7 +182,7 @@
                 <div class="category-row">昇段情報</div>
                 <ul class="boxes">
                     <li class="label-row">新規登録</li>
-                    <li class="row">
+                    <li class="detail-row">
                         <?= $this->Form->create($player, [
                             'class' => 'rank-form',
                             'type' => 'post',
@@ -219,7 +217,7 @@
                     </li>
                     <li class="label-row">昇段履歴</li>
                     <?php foreach ($player->player_ranks as $player_rank) : ?>
-                    <li class="row">
+                    <li class="detail-row">
                         <?= $this->Form->create($player, [
                             'class' => 'rank-form',
                             'type' => 'put',
@@ -264,7 +262,7 @@
                 <?php foreach ($player->title_score_details as $score) : ?>
                 <ul class="boxes">
                     <li class="genre-row"><?=h($score->target_year).'年度'?></li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">勝敗（国内）</div>
                             <div class="input-row">
@@ -312,7 +310,7 @@
                 <?php foreach ($player->old_scores as $key => $score) : ?>
                 <ul class="boxes">
                     <li class="genre-row"><?=h($score->target_year).'年度'?></li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">勝敗（国内）</div>
                             <div class="input-row">

--- a/src/Template/TitleScores/index.ctp
+++ b/src/Template/TitleScores/index.ctp
@@ -2,7 +2,6 @@
     <?php if (!isset($isDialog)) : ?>
     <div>
         <?=$this->Form->create($form, [
-            'id' => 'mainForm',
             'class' => 'main-form',
             'url' => ['_name' => 'find_scores'],
             'templates' => [
@@ -14,15 +13,15 @@
             <ul class="search-header">
                 <li class="search-row">
                     <div>
-                        <label>棋士名：</label>
+                        <label class="search-row_label">棋士名：</label>
                         <?=$this->Form->text('name', ['class' => 'name', 'maxlength' => 20]);?>
                     </div>
                     <div>
-                        <label>対象棋戦：</label>
+                        <label class="search-row_label">対象棋戦：</label>
                         <?= $this->cell('Countries')->render() ?>
                     </div>
                     <div>
-                        <label>対局年：</label>
+                        <label class="search-row_label">対局年：</label>
                         <?=
                             $this->MyForm->years('target_year', [
                                 'class' => 'year', 'empty' => true,
@@ -30,7 +29,7 @@
                         ?>
                     </div>
                     <div>
-                        <label>対局日：</label>
+                        <label class="search-row_label">対局日：</label>
                         <?=$this->Form->text('started', ['class' => 'date datepicker'])?>
                         <span>～</span>
                         <?=$this->Form->text('ended', ['class' => 'date datepicker'])?>
@@ -47,13 +46,13 @@
     <div class="search-results<?= ($this->isDialogMode() ? ' modal' : '') ?>">
         <ul class="table-header">
             <li class="table-row">
-                <span class="id">ID</span>
-                <span class="country">対象国</span>
-                <span class="date">日付</span>
-                <span class="name">勝者</span>
-                <span class="name">敗者</span>
+                <span class="table-column_id">ID</span>
+                <span class="table-column_country">対象国</span>
+                <span class="table-column_date">日付</span>
+                <span class="table-column_name">勝者</span>
+                <span class="table-column_name">敗者</span>
                 <?php if (!$this->isDialogMode()) : ?>
-                <span class="operation">操作</span>
+                <span class="table-column_operation">操作</span>
                 <?php endif ?>
             </li>
         </ul>
@@ -61,13 +60,13 @@
         <ul class="table-body">
             <?php foreach ($titleScores as $titleScore) : ?>
             <li class="table-row">
-                <span class="id"><?= h($titleScore->id) ?></span>
-                <span class="country"><?= h($titleScore->country->name.'棋戦') ?></span>
-                <span class="date"><?= h($titleScore->date) ?></span>
-                <span class="name"><?= $titleScore->getWinner($this->request->getData('player_id')) ?></span>
-                <span class="name"><?= $titleScore->getLoser($this->request->getData('player_id')) ?></span>
+                <span class="table-column_id"><?= h($titleScore->id) ?></span>
+                <span class="table-column_country"><?= h($titleScore->country->name.'棋戦') ?></span>
+                <span class="table-column_date"><?= h($titleScore->date) ?></span>
+                <span class="table-column_name"><?= $titleScore->getWinner($this->request->getData('player_id')) ?></span>
+                <span class="table-column_name"><?= $titleScore->getLoser($this->request->getData('player_id')) ?></span>
                 <?php if (!$this->isDialogMode()) : ?>
-                <span class="operation">
+                <span class="table-column_operation">
                     <?= $this->Form->postButton('勝敗変更', [
                         '_name' => 'update_scores', $titleScore->id,
                     ], [

--- a/src/Template/Titles/view.ctp
+++ b/src/Template/Titles/view.ctp
@@ -10,10 +10,8 @@
         <!-- マスタ -->
         <section data-contentname="title" class="tab-contents">
             <?=$this->Form->create($title, [
-                'id' => 'mainForm',
                 'class' => 'main-form',
                 'url' => ['_name' => 'update_title', $title->id],
-                'novalidate' => 'novalidate',
                 'templates' => [
                     'inputContainer' => '{{content}}',
                     'textFormGroup' => '{{input}}',
@@ -23,7 +21,7 @@
                 <?=$this->Form->hidden('id', ['value' => $title->id])?>
                 <div class="category-row"><?='タイトル情報（ID：'.h($title->id).'）'?></div>
                 <ul class="boxes">
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">タイトル名</div>
                             <div class="input-row"><?=$this->Form->text('name', ['maxlength' => 20])?></div>
@@ -37,7 +35,7 @@
                             <div class="input-row"><?=($title->country->name).'棋戦'?></div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">期</div>
                             <div class="input-row"><?=$this->Form->text('holding', ['maxlength' => 3, 'class' => 'holding'])?></div>
@@ -54,7 +52,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">HTMLファイル名</div>
                             <div class="input-row">
@@ -72,7 +70,7 @@
                             <div class="input-row"><?=$this->Date->formatToDateTime($title->modified)?></div>
                         </div>
                     </li>
-                    <li class="row">
+                    <li class="detail-row">
                         <div class="box">
                             <div class="label-row">その他備考</div>
                             <div class="input-row">
@@ -107,7 +105,7 @@
                     <?php if (!empty(($title->retention_histories))) : ?>
                         <?php if (($retention = $title->now_retention)) : ?>
                         <li class="label-row">現在の保持情報</li>
-                        <li class="row">
+                        <li class="detail-row">
                             <div class="box">
                                 <div class="input-row">
                                     <div class="box">
@@ -126,7 +124,7 @@
                         <?php endif ?>
                         <li class="label-row">保持情報（履歴）</li>
                         <?php foreach ($title->histories as $history) : ?>
-                        <li class="row">
+                        <li class="detail-row">
                             <div class="box">
                                 <div class="input-row">
                                     <div class="box">

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -1,7 +1,6 @@
 <?= $this->Form->create($form, [
     'method' => 'post',
     'url' => ['_name' => 'login'],
-    'novalidate' => 'novalidate',
     'templates' => [
         'inputContainer' => '{{content}}',
         'textFormGroup' => '{{input}}',


### PR DESCRIPTION
### 概要

- 不要クラスの整理

### 対応内容

- HTML要素への指定削除（クラス化）
- クラスにprefixを付与（汎用的な名前のバッティング防止）
- 詳細ダイアログのスタイルを個別scssファイルに分割
- formの`novalidate`、`id`削除
