### PR TITLE
merges #333

### DIFF
--- a/src/Controller/PlayersController.php
+++ b/src/Controller/PlayersController.php
@@ -86,12 +86,23 @@ class PlayersController extends AppController
                 throw new BadRequestException(__('所属国を指定してください。'));
             }
 
-            // モデルを生成し、所属国と所属組織を設定
+            // モデルを生成し、パラメータを設定
             $organization = $this->Organizations->findByCountryId($countryId)->firstOrFail();
-            $player = $this->Players->newEntity([
+            $params = [
                 'country_id' => $countryId,
                 'organization_id' => $organization->id,
-            ]);
+            ];
+            if (($sex = $this->request->getQuery('sex'))) {
+                $params['sex'] = $sex;
+            }
+            if (($joined = $this->request->getQuery('joined'))) {
+                $params['joined'] = $joined;
+            }
+            $player = $this->Players->newEntity($params);
+            // エラーあり
+            if (($errors = $player->getErrors())) {
+                $this->_setErrors(400, $errors);
+            }
         }
 
         return $this->set('player', $player)->_renderWithDialog('view');
@@ -139,7 +150,11 @@ class PlayersController extends AppController
         if (!$id && $this->request->getData('is_continue')) {
             return $this->redirect([
                 '_name' => 'new_player',
-                '?' => ['country_id' => $player->country_id],
+                '?' => [
+                    'country_id' => $player->country_id,
+                    'sex' => $player->sex,
+                    'joined' => $player->joined,
+                ],
             ]);
         }
 

--- a/src/Locale/ja_JP/validation.po
+++ b/src/Locale/ja_JP/validation.po
@@ -90,3 +90,6 @@ msgstr "{0}は{1}文字以上で入力してください。"
 
 msgid "field {0} is {1} format only"
 msgstr "{0}は「{1}」形式で入力してください。"
+
+msgid "field {0} is natural number only"
+msgstr "{0}は自然数で入力してください。"

--- a/src/Model/Table/PlayersTable.php
+++ b/src/Model/Table/PlayersTable.php
@@ -49,14 +49,18 @@ class PlayersTable extends AppTable
     {
         return $validator
             ->allowEmpty(['name_other', 'birthday'])
-            ->notEmpty(['name', 'name_english', 'joined'])
+            ->notEmpty([
+                'country_id', 'rank_id', 'organization_id',
+                'name', 'name_english', 'joined', 'sex',
+            ])
             ->maxLength('name', 20)
             ->maxLength('name_english', 40)
             ->alphaNumeric('name_english')
             ->maxLength('name_other', 20)
+            ->naturalNumber('joined')
+            ->lengthBetween('joined', [4, 8])
             ->date('birthday', 'y/m/d')
-            ->date('retired', 'y/m/d')
-            ->date('joined', 'y/m/d', null, 'create');
+            ->date('retired', 'y/m/d');
     }
 
     /**

--- a/src/Template/Players/index.ctp
+++ b/src/Template/Players/index.ctp
@@ -28,7 +28,7 @@
                 </div>
                 <div>
                     <label class="search-row_label">性別：</label>
-                    <?= $this->MyForm->sexes(['class' => 'sex', 'empty' => true]) ?>
+                    <?= $this->Form->sexes(['class' => 'sex', 'empty' => true]) ?>
                 </div>
                 <div>
                     <label class="search-row_label">入段年：</label>
@@ -54,7 +54,7 @@
             <li class="search-row">
                 <div>
                     <label class="search-row_label">引退者：</label>
-                    <?= $this->MyForm->filters('is_retired', ['class' => 'excluded']) ?>
+                    <?= $this->Form->filters('is_retired', ['class' => 'excluded']) ?>
                 </div>
                 <?php if (!empty($players)) : ?>
                 <div class="result-count">

--- a/src/Template/Players/view.ctp
+++ b/src/Template/Players/view.ctp
@@ -105,28 +105,15 @@
                         <div class="box">
                             <div class="label-row">入段日</div>
                             <div class="input-row">
-                                <?= $this->Form->date('input_joined', [
-                                    'empty' => [
-                                        'year' => false,
-                                        'month' => ['' => '-'],
-                                        'day' => ['' => '-'],
-                                    ],
-                                    'year' => [
-                                        'start' => '1920',
-                                        'end' => date('Y'),
-                                        'class' => 'joined',
-                                        'suffix' => '年',
-                                    ],
-                                    'month' => [
-                                        'class' => 'joined',
-                                        'suffix' => '月',
-                                    ],
-                                    'day' => [
-                                        'class' => 'joined',
-                                        'suffix' => '日',
-                                    ],
-                                    'monthNames' => false,
-                                ]); ?>
+                                <?=
+                                    $this->Form->selectDate('input_joined', [
+                                        'empty' => [
+                                            'year' => false,
+                                            'month' => ['' => '-'],
+                                            'day' => ['' => '-'],
+                                        ],
+                                    ]);
+                                ?>
                             </div>
                         </div>
                     </li>
@@ -134,7 +121,7 @@
                         <div class="box">
                             <div class="label-row">性別</div>
                             <div class="input-row">
-                                <?= $this->MyForm->sexes(['value' => $player->sex, 'class' => 'sex']) ?>
+                                <?= $this->Form->sexes(['value' => $player->sex, 'class' => 'sex']) ?>
                             </div>
                         </div>
                         <div class="box">
@@ -269,7 +256,7 @@
                                 <?= $score->win_point ?>勝<?= $score->lose_point ?>敗<?= $score->draw_point ?>分
                                 <span class="percent">
                                     （勝率<strong>
-                                        <?= $this->MyForm->percent($score->win_point, $score->lose_point)?>
+                                        <?= $this->Form->percent($score->win_point, $score->lose_point)?>
                                     </strong>）
                                 </span>
                             </div>
@@ -282,7 +269,7 @@
                                 <?= $score->draw_point_world ?>分
                                 <span class="percent">
                                     （勝率<strong>
-                                        <?= $this->MyForm->percent($score->win_point_world, $score->lose_point_world) ?>
+                                        <?= $this->Form->percent($score->win_point_world, $score->lose_point_world) ?>
                                     </strong>）
                                 </span>
                             </div>
@@ -315,14 +302,14 @@
                             <div class="label-row">勝敗（国内）</div>
                             <div class="input-row">
                                 <?=h($score->win_point)?>勝<?=h($score->lose_point)?>敗<?=h($score->draw_point)?>分
-                                <span class="percent">（勝率<strong><?=$this->MyForm->percent($score->win_point, $score->lose_point)?></strong>）</span>
+                                <span class="percent">（勝率<strong><?=$this->Form->percent($score->win_point, $score->lose_point)?></strong>）</span>
                             </div>
                         </div>
                         <div class="box">
                             <div class="label-row">勝敗（国際）</div>
                             <div class="input-row">
                                 <?=$score->win_point_world?>勝<?=$score->lose_point_world?>敗<?=$score->draw_point_world?>分
-                                <span class="percent">（勝率<strong><?=$this->MyForm->percent($score->win_point_world, $score->lose_point_world)?></strong>）</span>
+                                <span class="percent">（勝率<strong><?=$this->Form->percent($score->win_point_world, $score->lose_point_world)?></strong>）</span>
                             </div>
                         </div>
                         <div class="box">

--- a/src/Template/TitleScores/index.ctp
+++ b/src/Template/TitleScores/index.ctp
@@ -23,7 +23,7 @@
                     <div>
                         <label class="search-row_label">対局年：</label>
                         <?=
-                            $this->MyForm->years('target_year', [
+                            $this->Form->years('target_year', [
                                 'class' => 'year', 'empty' => true,
                             ]);
                         ?>

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -34,6 +34,7 @@ class Validator extends BaseValidator
         'maxLength' => 'field {0} length is under the {1}',
         'range' => 'field {0} range is {1} - {2}',
         'invalidFormat' => 'field {0} is {1} format only',
+        'naturalNumber' => 'field {0} is natural number only',
     ];
 
     /**

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -10,6 +10,18 @@ use Cake\View\View;
 class AppView extends View
 {
     /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadHelper('Form', [
+            'className' => 'MyForm',
+        ]);
+    }
+
+    /**
      * 認証済みかを判定
      *
      * @return bool

--- a/src/View/Helper/MyFormHelper.php
+++ b/src/View/Helper/MyFormHelper.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gotea\View\Helper;
 
+use Cake\I18n\Date;
 use Cake\View\Helper\FormHelper;
 use Gotea\Utility\CalculatorTrait;
 
@@ -10,6 +11,34 @@ use Gotea\Utility\CalculatorTrait;
 class MyFormHelper extends FormHelper
 {
     use CalculatorTrait;
+
+    /**
+     * 入段日を取得します。
+     *
+     * @param string $name フィールド名
+     * @param array $attributes オプション
+     * @return string Generated set of select boxes for time formats chosen.
+     */
+    public function selectDate(string $name, array $attributes)
+    {
+        return $this->date($name, [
+            'year' => [
+                'start' => '1920',
+                'end' => Date::now()->addYears(1)->year,
+                'class' => 'joined',
+                'suffix' => '年',
+            ],
+            'month' => [
+                'class' => 'joined',
+                'suffix' => '月',
+            ],
+            'day' => [
+                'class' => 'joined',
+                'suffix' => '日',
+            ],
+            'monthNames' => false,
+        ] + $attributes);
+    }
 
     /**
      * 性別一覧を取得します。

--- a/tests/TestCase/Controller/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/PlayersControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Gotea\Test\TestCase\Controller;
 
+use Cake\I18n\Date;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -175,7 +176,8 @@ class PlayersControllerTest extends AppTestCase
     public function testCreateFailed()
     {
         $this->enableCsrfToken();
-        $name = '棋士新規作成' . date('YmdHis');
+        $now = Date::now();
+        $name = '棋士新規作成' . $now->format('YmdHis');
         $data = [
             'name' => $name,
             'name_english' => '',
@@ -183,10 +185,10 @@ class PlayersControllerTest extends AppTestCase
             'country_id' => 1,
             'organization_id' => 1,
             'sex' => '男性',
-            'joined' => [
-                'year' => date('Y'),
-                'month' => date('m'),
-                'day' => date('d'),
+            'input_joined' => [
+                'year' => $now->year,
+                'month' => $now->month,
+                'day' => $now->day,
             ],
             'birthday' => '',
         ];
@@ -206,7 +208,8 @@ class PlayersControllerTest extends AppTestCase
     public function testCreate()
     {
         $this->enableCsrfToken();
-        $name = '棋士新規作成' . date('YmdHis');
+        $now = Date::now();
+        $name = '棋士新規作成' . $now->format('YmdHis');
         $data = [
             'name' => $name,
             'name_english' => 'test',
@@ -214,12 +217,12 @@ class PlayersControllerTest extends AppTestCase
             'country_id' => 1,
             'organization_id' => 1,
             'sex' => '男性',
-            'joined' => [
-                'year' => date('Y'),
-                'month' => date('m'),
-                'day' => date('d'),
+            'input_joined' => [
+                'year' => $now->year,
+                'month' => $now->month,
+                'day' => $now->day,
             ],
-            'birthday' => date('Y/m/d'),
+            'birthday' => $now->format('Y/m/d'),
         ];
         $this->post(['_name' => 'create_player'], $data);
         $this->assertResponseSuccess();
@@ -237,7 +240,8 @@ class PlayersControllerTest extends AppTestCase
     public function testCreateWithContinue()
     {
         $this->enableCsrfToken();
-        $name = '棋士新規作成' . date('YmdHis');
+        $now = Date::now();
+        $name = '棋士新規作成' . $now->format('YmdHis');
         $data = [
             'name' => $name,
             'name_english' => 'test',
@@ -245,16 +249,21 @@ class PlayersControllerTest extends AppTestCase
             'country_id' => 1,
             'organization_id' => 1,
             'sex' => '男性',
-            'joined' => [
-                'year' => date('Y'),
-                'month' => date('m'),
-                'day' => date('d'),
+            'input_joined' => [
+                'year' => $now->year,
+                'month' => $now->month,
+                'day' => $now->day,
             ],
             'birthday' => date('Y/m/d'),
             'is_continue' => true,
         ];
         $this->post(['_name' => 'create_player'], $data);
-        $this->assertRedirect(['_name' => 'new_player', 'country_id' => 1]);
+        $this->assertRedirect([
+            '_name' => 'new_player',
+            'country_id' => 1,
+            'sex' => '男性',
+            'joined' => $now->format('Ymd'),
+        ]);
         $this->assertResponseNotContains('<nav class="nav">');
 
         // データが存在すること
@@ -270,7 +279,8 @@ class PlayersControllerTest extends AppTestCase
     {
         $this->enableCsrfToken();
         $before = $this->Players->get(1);
-        $name = '棋士更新' . date('YmdHis');
+        $now = Date::now();
+        $name = '棋士更新' . $now->format('YmdHis');
         $data = [
             'id' => 1,
             'name' => $name,
@@ -278,10 +288,10 @@ class PlayersControllerTest extends AppTestCase
             'rank_id' => 1,
             'country_id' => 1,
             'organization_id' => 1,
-            'joined' => [
-                'year' => date('Y'),
-                'month' => date('m'),
-                'day' => date('d'),
+            'input_joined' => [
+                'year' => $now->year,
+                'month' => $now->month,
+                'day' => $now->day,
             ],
             'birthday' => '',
         ];
@@ -302,7 +312,8 @@ class PlayersControllerTest extends AppTestCase
     {
         $this->enableCsrfToken();
         $before = $this->Players->get(1);
-        $name = '棋士更新' . date('YmdHis');
+        $now = Date::now();
+        $name = '棋士更新' . $now->format('YmdHis');
         $data = [
             'id' => 1,
             'name' => $name,
@@ -310,10 +321,10 @@ class PlayersControllerTest extends AppTestCase
             'rank_id' => 1,
             'country_id' => 1,
             'organization_id' => 1,
-            'joined' => [
-                'year' => date('Y'),
-                'month' => date('m'),
-                'day' => date('d'),
+            'input_joined' => [
+                'year' => $now->year,
+                'month' => $now->month,
+                'day' => $now->day,
             ],
             'birthday' => date('Y/m/d'),
         ];


### PR DESCRIPTION
### 概要

- 棋士の連続作成時、性別・入段日を維持する

### 対応内容

- 連続作成時のパラメータに`sex`、`joined`を追加
- バリデーションルール見直し
- `MyFormHelper`を`Form`にマッピング