### PR TITLE
merges #419

### DIFF
--- a/src/Model/Table/TitleScoreDetailsTable.php
+++ b/src/Model/Table/TitleScoreDetailsTable.php
@@ -41,11 +41,9 @@ class TitleScoreDetailsTable extends AppTable
         $this->belongsTo('Players')
             ->setJoinType('INNER');
         $this->belongsTo('Winner', ['className' => 'Players'])
-            ->setForeignKey('player_id')
-            ->setJoinType('INNER');
+            ->setForeignKey('player_id');
         $this->belongsTo('Loser', ['className' => 'Players'])
-            ->setForeignKey('player_id')
-            ->setJoinType('INNER');
+            ->setForeignKey('player_id');
     }
 
     /**


### PR DESCRIPTION
### 概要

- 対局者に未登録棋士が含まれている場合、タイトル成績検索に該当レコードが表示されなくなる

### 対応内容

- タイトル成績詳細→棋士のJOINを`INNER`→`LEFT`に
