### PR TITLE
merges #426

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -104,7 +104,7 @@
     overflow-y: auto;
 
     * {
-        font-size: 90%;
+        font-size: .8rem;
     }
 
     &-header {
@@ -115,7 +115,11 @@
     }
 
     &-row {
-        padding: 5px 5px 5px 15px;
+        padding: 8px 5px 8px 15px;
+
+        &-text {
+            margin-left: 5px;
+        }
     }
 }
 

--- a/src/Model/Table/PlayerRanksTable.php
+++ b/src/Model/Table/PlayerRanksTable.php
@@ -2,6 +2,8 @@
 namespace Gotea\Model\Table;
 
 use Cake\Datasource\EntityInterface;
+use Cake\I18n\Date;
+use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
@@ -103,5 +105,23 @@ class PlayerRanksTable extends AppTable
     {
         return $this->findByPlayerId($playerId)
             ->contain(['Ranks'])->orderDesc('Ranks.rank_numeric')->all();
+    }
+
+    /**
+     * 最近の昇段者を取得します。
+     *
+     * @return \Cake\ORM\Query 生成されたクエリ
+     */
+    public function findRecentPromoted()
+    {
+        return $this->find()
+            ->contain([
+                'Players',
+                'Ranks' => function (Query $q) {
+                    return $q->where(['rank_numeric >' => 1]);
+                },
+            ])
+            ->where(['promoted >=' => Date::now()->addMonths(-1)])
+            ->orderDesc('promoted');
     }
 }

--- a/src/Template/Cell/Navigation/display.ctp
+++ b/src/Template/Cell/Navigation/display.ctp
@@ -9,7 +9,15 @@
     </li>
     <?php foreach ($recent as $row) : ?>
     <li class="recent-ranks-data-row">
-        <p><?= h($row->player->name) ?> <?= h($row->rank->name) ?>に昇段</p>
+        <p>
+            <a class="view-link<?= ($row->player->isFemale() ? ' female' : '') ?>"
+                @click="openModal('<?= $this->Url->build(['_name' => 'view_player', $row->player->id]) ?>')">
+                <?= h($row->player->name) ?>
+            </a>
+            <span class="recent-ranks-data-row-text">
+                <?= h($row->rank->name) ?>に昇段
+            </span>
+        </p>
     </li>
     <?php endforeach ?>
     <?php endforeach ?>

--- a/src/View/Cell/NavigationCell.php
+++ b/src/View/Cell/NavigationCell.php
@@ -1,7 +1,6 @@
 <?php
 namespace Gotea\View\Cell;
 
-use Cake\I18n\Date;
 use Cake\View\Cell;
 
 /**
@@ -25,13 +24,16 @@ class NavigationCell extends Cell
     public function display()
     {
         $this->loadModel('PlayerRanks');
-        $recents = $this->PlayerRanks->find()
-            ->contain(['Players', 'Ranks'])
-            ->where(['promoted >=' => Date::now()->addMonths(-1)])
-            ->orderDesc('promoted')
+        $recents = $this->PlayerRanks
+            ->findRecentPromoted()
+            ->reject(function ($item) {
+                // 入段日と昇段日が同じ（＝入段時点の段位の）場合は除外
+                return $item->player->joined === $item->promoted->format('Ymd');
+            })
             ->groupBy(function ($item) {
                 return $item->promoted->format('Y/m/d');
             });
+
         $this->set('recents', $recents);
     }
 }

--- a/tests/Fixture/PlayerRanksFixture.php
+++ b/tests/Fixture/PlayerRanksFixture.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gotea\Test\Fixture;
 
+use Cake\I18n\Date;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
@@ -54,4 +55,29 @@ class PlayerRanksFixture extends TestFixture
             'modified' => '2017-11-26 15:09:51'
         ],
     ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function init()
+    {
+        // 最近の昇段情報
+        $now = Date::now();
+        $this->records[] = [
+            'player_id' => 1,
+            'rank_id' => 2,
+            'promoted' => $now->format('Y/m/d'),
+            'created' => '2017-11-26 15:09:51',
+            'modified' => '2017-11-26 15:09:51'
+        ];
+        $this->records[] = [
+            'player_id' => 1,
+            'rank_id' => 3,
+            'promoted' => $now->format('Y/m/d'),
+            'created' => '2017-11-26 15:09:51',
+            'modified' => '2017-11-26 15:09:51'
+        ];
+
+        parent::init();
+    }
 }

--- a/tests/TestCase/Controller/PlayerRanksControllerTest.php
+++ b/tests/TestCase/Controller/PlayerRanksControllerTest.php
@@ -57,20 +57,48 @@ class PlayerRanksControllerTest extends AppTestCase
      *
      * @return void
      */
+    public function testCreateFailed()
+    {
+        $this->enableCsrfToken();
+        $conditions = [
+            'player_id' => 1,
+            'rank_id' => 2,
+        ];
+        // データがすでに存在すること
+        $this->assertEquals(1, $this->PlayerRanks->find()->where($conditions)->count());
+
+        $data = $conditions;
+        $data['promoted'] = '2017/12/10';
+        $this->post(['_name' => 'create_ranks', 1], $data);
+        $this->assertRedirect(['_name' => 'view_player', 'tab' => 'ranks', 1]);
+
+        // 1件のまま
+        $this->assertEquals(1, $this->PlayerRanks->find()->where($conditions)->count());
+    }
+
+    /**
+     * Test create method
+     *
+     * @return void
+     */
     public function testCreate()
     {
         $this->enableCsrfToken();
-        $data = [
+        $conditions = [
             'player_id' => 1,
-            'rank_id' => 2,
-            'promoted' => '2017/12/10',
+            'rank_id' => 4,
         ];
+        // データが存在しないこと
+        $this->assertEquals(0, $this->PlayerRanks->find()->where($conditions)->count());
+
+        $data = $conditions;
+        $data['promoted'] = '2017/12/10';
         $this->post(['_name' => 'create_ranks', 1], $data);
         $this->assertRedirect(['_name' => 'view_player', 'tab' => 'ranks', 1]);
         $this->assertResponseNotContains('<nav class="nav">');
 
         // データが存在すること
-        $this->assertEquals(1, $this->PlayerRanks->find()->where($data)->count());
+        $this->assertEquals(1, $this->PlayerRanks->find()->where($conditions)->count());
     }
 
     /**
@@ -80,18 +108,16 @@ class PlayerRanksControllerTest extends AppTestCase
      */
     public function testUpdate()
     {
+        // データが存在すること
+        $rank = $this->PlayerRanks->get(1);
+        $this->assertNotNull($rank);
+
         $this->enableCsrfToken();
-        $data = [
-            'id' => 1,
-            'player_id' => 1,
-            'rank_id' => 3,
-            'promoted' => '2017/12/10',
-        ];
-        $this->put(['_name' => 'update_ranks', 1, 1], $data);
+        $this->put(['_name' => 'update_ranks', $rank->player_id, $rank->id], $rank->toArray());
         $this->assertRedirect(['_name' => 'view_player', 'tab' => 'ranks', 1]);
         $this->assertResponseNotContains('<nav class="nav">');
 
         // データが存在すること
-        $this->assertEquals(1, $this->PlayerRanks->find()->where($data)->count());
+        $this->assertEquals(1, $this->PlayerRanks->find()->where($rank->toArray())->count());
     }
 }

--- a/tests/TestCase/Model/Table/PlayerRanksTableTest.php
+++ b/tests/TestCase/Model/Table/PlayerRanksTableTest.php
@@ -146,4 +146,17 @@ class PlayerRanksTableTest extends TestCase
         $ranks = $this->PlayerRanks->findRanks(2);
         $this->assertEquals(0, $ranks->count());
     }
+
+    /**
+     * 最近の昇段者取得
+     *
+     * @return void
+     */
+    public function testFindRecentPromoted()
+    {
+        $ranks = $this->PlayerRanks->findRecentPromoted();
+        $ranks->each(function ($item) {
+            $this->assertGreaterThan(1, $item->rank->rank_numeric);
+        });
+    }
 }

--- a/tests/TestCase/View/Cell/NavigationCellTest.php
+++ b/tests/TestCase/View/Cell/NavigationCellTest.php
@@ -31,6 +31,18 @@ class NavigationCellTest extends TestCase
     public $Navigation;
 
     /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'app.player_ranks',
+        'app.players',
+        'app.countries',
+        'app.ranks',
+    ];
+
+    /**
      * setUp method
      *
      * @return void
@@ -63,6 +75,13 @@ class NavigationCellTest extends TestCase
     public function testDisplay()
     {
         $this->Navigation->display();
-        $this->assertNotNull($this->Navigation->viewVars['recents']);
+        $recents = $this->Navigation->viewVars['recents'];
+        $this->assertNotNull($recents);
+        foreach ($recents as $items) {
+            foreach ($items as $item) {
+                $this->assertGreaterThan(1, $item->rank->rank_numeric);
+                $this->assertNotEquals($item->player->joined, $item->promoted->format('Ymd'));
+            }
+        }
     }
 }


### PR DESCRIPTION
### 概要

- 「最近の昇段者」に入段日と一致する情報を表示しない

### 対応内容

- 初段に合致するものはクエリで除外
- `players.joined`と`player_ranks.promoted`は型が異なるため、こちらはPHP側でreject
- ナビゲーションのレイアウト微調整
