### PR TITLE
merges #427

### DIFF
--- a/src/Controller/PlayerRanksController.php
+++ b/src/Controller/PlayerRanksController.php
@@ -2,6 +2,8 @@
 
 namespace Gotea\Controller;
 
+use Cake\Utility\Hash;
+
 /**
  * 昇段情報コントローラ
  *
@@ -25,14 +27,15 @@ class PlayerRanksController extends AppController
     /**
      * 登録処理
      *
-     * @param int $id 棋士ID
+     * @param int $playerId 棋士ID
      * @return \Cake\Http\Response|null
      */
-    public function create(int $id)
+    public function create(int $playerId)
     {
-        // バリデーション
-        $rank = $this->PlayerRanks->newEntity($this->request->getParsedBody());
-        $rank->player_id = $id;
+        $data = Hash::insert($this->request->getData(), 'player_id', $playerId);
+        $rank = $this->PlayerRanks->newEntity($data);
+
+        // 保存
         if (!$this->PlayerRanks->save($rank)) {
             $this->_setErrors(400, $rank->getErrors());
         } else {
@@ -42,22 +45,24 @@ class PlayerRanksController extends AppController
         return $this->redirect([
             '_name' => 'view_player',
             '?' => ['tab' => 'ranks'],
-            $id,
+            $playerId,
         ]);
     }
 
     /**
      * 更新処理
      *
-     * @param int $id 棋士ID
-     * @param int $rowId 昇段情報ID
+     * @param int $playerId 棋士ID
+     * @param int $id 昇段情報ID
      * @return \Cake\Http\Response|null
      */
-    public function update(int $id, int $rowId)
+    public function update(int $playerId, int $id)
     {
-        // バリデーション
-        $rank = $this->PlayerRanks->get($rowId);
-        $this->PlayerRanks->patchEntity($rank, $this->request->getParsedBody());
+        $data = Hash::insert($this->request->getData(), 'player_id', $playerId);
+        $rank = $this->PlayerRanks->get($id);
+        $this->PlayerRanks->patchEntity($rank, $data);
+
+        // 保存
         if (!$this->PlayerRanks->save($rank)) {
             $this->_setErrors(400, $rank->getErrors());
         } else {
@@ -67,7 +72,7 @@ class PlayerRanksController extends AppController
         return $this->redirect([
             '_name' => 'view_player',
             '?' => ['tab' => 'ranks'],
-            $id,
+            $playerId,
         ]);
     }
 }

--- a/src/Model/Table/PlayerRanksTable.php
+++ b/src/Model/Table/PlayerRanksTable.php
@@ -89,7 +89,7 @@ class PlayerRanksTable extends AppTable
             $players = TableRegistry::get('Players');
             $player = $players->get($entity->player_id);
             $player->rank_id = $entity->rank_id;
-            $players->save($player);
+            $players->save($player, $options);
         }
 
         return $save;

--- a/src/Model/Table/PlayersTable.php
+++ b/src/Model/Table/PlayersTable.php
@@ -98,10 +98,11 @@ class PlayersTable extends AppTable
         if (!$entity->is_retired) {
             $entity->retired = null;
         }
+        $new = $entity->isNew();
         $save = parent::save($entity, $options);
 
         // 新規作成時には昇段情報も登録
-        if ($save && $entity->isNew()) {
+        if ($save && $new) {
             // 入段日を登録時段位の昇段日として設定
             $promoted = Date::parseDate($entity->joined, 'yyyyMMdd');
 

--- a/tests/TestCase/Model/Table/PlayerRanksTableTest.php
+++ b/tests/TestCase/Model/Table/PlayerRanksTableTest.php
@@ -126,6 +126,50 @@ class PlayerRanksTableTest extends TestCase
     }
 
     /**
+     * 保存
+     *
+     * @return void
+     */
+    public function testSave()
+    {
+        $rank = $this->PlayerRanks->newEntity([
+            'player_id' => 3,
+            'rank_id' => 3,
+            'promoted' => '2018/01/03',
+        ]);
+
+        $save = $this->PlayerRanks->save($rank, [
+            'account' => env('TEST_USER'),
+        ]);
+        $this->assertNotEquals(false, $save);
+
+        // 棋士情報の段位とは一致しない
+        $saveRank = $this->PlayerRanks->get($save->id, [
+            'contain' => 'Players',
+        ]);
+        $this->assertNotEquals($saveRank->rank_id, $saveRank->player->rank_id);
+
+        // 最新として登録
+        $rank = $this->PlayerRanks->newEntity([
+            'player_id' => 3,
+            'rank_id' => 4,
+            'promoted' => '2018/01/03',
+            'newest' => true,
+        ]);
+
+        $save = $this->PlayerRanks->save($rank, [
+            'account' => env('TEST_USER'),
+        ]);
+        $this->assertNotEquals(false, $save);
+
+        // 棋士情報の段位と一致
+        $saveRank = $this->PlayerRanks->get($save->id, [
+            'contain' => 'Players',
+        ]);
+        $this->assertEquals($saveRank->rank_id, $saveRank->player->rank_id);
+    }
+
+    /**
      * 昇段情報取得（データ有り）
      *
      * @return void


### PR DESCRIPTION
### 概要

- 棋士登録時、昇段情報にデータが登録されない

### 対応内容

- `$entity->isNew()`するタイミングを`save()`の前に
- 棋士IDを`newEntity()`および`patchEntity()`の引数に含める
- 最新登録時の`PlayersTable::save()`へ`$options`を渡す
