### PR TITLE
アプリ固有のprotected、privateメソッド・変数を「_」始まりにしない

### DIFF
--- a/src/Controller/Api/ApiController.php
+++ b/src/Controller/Api/ApiController.php
@@ -45,7 +45,7 @@ abstract class ApiController extends Controller
      * @param string|null $message メッセージ
      * @return \Cake\Http\Response
      */
-    protected function _renderError($code = 500, $message = null)
+    protected function renderError($code = 500, $message = null)
     {
         $this->response = $this->response->withStatus($code);
 
@@ -53,7 +53,7 @@ abstract class ApiController extends Controller
             $message = $this->response->getReasonPhrase();
         }
 
-        return $this->_renderJson([
+        return $this->renderJson([
             'code' => $code,
             'message' => $message,
         ]);
@@ -65,7 +65,7 @@ abstract class ApiController extends Controller
      * @param array $json JSONデータ
      * @return \Cake\Http\Response
      */
-    protected function _renderJson($json = [])
+    protected function renderJson($json = [])
     {
         return $this->set([
             'response' => $json,

--- a/src/Controller/Api/CountriesController.php
+++ b/src/Controller/Api/CountriesController.php
@@ -18,6 +18,6 @@ class CountriesController extends ApiController
 
         $countries = $this->Countries->findAllHasCode($hasTitle);
 
-        return $this->_renderJson($countries);
+        return $this->renderJson($countries);
     }
 }

--- a/src/Controller/Api/PlayersController.php
+++ b/src/Controller/Api/PlayersController.php
@@ -24,7 +24,7 @@ class PlayersController extends ApiController
         $players = $query->limit($this->request->getData('limit', 100))
             ->offset($this->request->getData('offset', 0));
 
-        return $this->_renderJson([
+        return $this->renderJson([
             'count' => $query->count(),
             'results' => $players->map(function ($item, $key) {
                 return $item->toArray();
@@ -42,7 +42,7 @@ class PlayersController extends ApiController
     {
         $ranks = $this->Players->findRanksCount($countryId);
 
-        return $this->_renderJson($ranks);
+        return $this->renderJson($ranks);
     }
 
     /**
@@ -59,7 +59,7 @@ class PlayersController extends ApiController
         $to = $this->request->getQuery('to');
 
         // ランキングデータ取得
-        $json = $this->__ranking([
+        $json = $this->getRankingData([
             'country' => $country,
             'year' => $year,
             'limit' => $limit,
@@ -69,10 +69,10 @@ class PlayersController extends ApiController
         ]);
 
         if (!$json) {
-            return $this->_renderError(404);
+            return $this->renderError(404);
         }
 
-        return $this->_renderJson($json);
+        return $this->renderJson($json);
     }
 
     /**
@@ -89,7 +89,7 @@ class PlayersController extends ApiController
         $to = $this->request->getData('to');
 
         // ランキングデータ取得
-        $json = $this->__ranking([
+        $json = $this->getRankingData([
             'country' => $country,
             'year' => $year,
             'limit' => $limit,
@@ -98,7 +98,7 @@ class PlayersController extends ApiController
         ]);
 
         if (!$json) {
-            return $this->_renderError(404);
+            return $this->renderError(404);
         }
 
         // ファイル作成
@@ -108,19 +108,19 @@ class PlayersController extends ApiController
         Log::info("JSONファイル出力：{$file->path}");
 
         if (!$file->write(json_encode($json))) {
-            return $this->_renderError(500, 'JSON出力失敗');
+            return $this->renderError(500, 'JSON出力失敗');
         }
 
-        return $this->_renderJson($json);
+        return $this->renderJson($json);
     }
 
     /**
      * ランキングを取得します。
      *
      * @param array $params パラメータ
-     * @return array
+     * @return array ランキングデータ
      */
-    private function __ranking(array $params) : array
+    private function getRankingData(array $params) : array
     {
         // モデルのロード
         $this->loadModel('Countries');

--- a/src/Controller/Api/RetentionHistoriesController.php
+++ b/src/Controller/Api/RetentionHistoriesController.php
@@ -19,7 +19,7 @@ class RetentionHistoriesController extends ApiController
             'contain' => ['Players', 'Ranks'],
         ]);
 
-        return $this->_renderJson([
+        return $this->renderJson([
             'id' => $history->id,
             'titleId' => $history->title_id,
             'holding' => $history->holding,

--- a/src/Controller/Api/TitlesController.php
+++ b/src/Controller/Api/TitlesController.php
@@ -22,7 +22,7 @@ class TitlesController extends ApiController
         // 検索
         $titles = $this->Titles->findTitles($this->request->getQuery());
 
-        return $this->_renderJson($titles->map(new TitlesIterator));
+        return $this->renderJson($titles->map(new TitlesIterator));
     }
 
     /**
@@ -36,10 +36,10 @@ class TitlesController extends ApiController
         $title = $this->Titles->createEntity(null, $input);
 
         if (!$this->Titles->save($title)) {
-            return $this->_renderError(400, $title->getValidateErrors());
+            return $this->renderError(400, $title->getValidateErrors());
         }
 
-        return $this->_renderJson($title->toArray());
+        return $this->renderJson($title->toArray());
     }
 
     /**
@@ -54,10 +54,10 @@ class TitlesController extends ApiController
         $title = $this->Titles->createEntity($id, $input);
 
         if (!$this->Titles->save($title)) {
-            return $this->_renderError(400, $title->getValidateErrors());
+            return $this->renderError(400, $title->getValidateErrors());
         }
 
-        return $this->_renderJson($title->toArray());
+        return $this->renderJson($title->toArray());
     }
 
     /**
@@ -75,9 +75,9 @@ class TitlesController extends ApiController
         Log::info("JSONファイル出力：{$file->path}");
 
         if (!$file->write(json_encode($titles))) {
-            return $this->_renderError(500, 'JSON出力失敗');
+            return $this->renderError(500, 'JSON出力失敗');
         }
 
-        return $this->_renderJson($titles->toArray());
+        return $this->renderJson($titles->toArray());
     }
 }

--- a/src/Controller/Api/YearsController.php
+++ b/src/Controller/Api/YearsController.php
@@ -25,6 +25,6 @@ class YearsController extends ApiController
             ];
         }
 
-        return $this->_renderJson($years);
+        return $this->renderJson($years);
     }
 }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -75,9 +75,9 @@ abstract class AppController extends Controller
      * @param string|null $layout Layout to use
      * @return \Cake\Http\Response|null
      */
-    protected function _renderWith(string $title, $view = null, $layout = null)
+    protected function renderWith(string $title, $view = null, $layout = null)
     {
-        return $this->_setTitle($title)->render($view, $layout);
+        return $this->setTitle($title)->render($view, $layout);
     }
 
     /**
@@ -87,9 +87,9 @@ abstract class AppController extends Controller
      * @param string|null $layout Layout to use
      * @return \Cake\Http\Response|null
      */
-    protected function _renderWithDialog($view = null, $layout = null)
+    protected function renderWithDialog($view = null, $layout = null)
     {
-        return $this->_enableDialogMode()->render($view, $layout);
+        return $this->enableDialogMode()->render($view, $layout);
     }
 
     /**
@@ -102,9 +102,9 @@ abstract class AppController extends Controller
      * @param string|null $layout Layout to use
      * @return \Cake\Http\Response|null
      */
-    protected function _renderWithErrors(int $code, $errors, $title, $view = null, $layout = null)
+    protected function renderWithErrors(int $code, $errors, $title, $view = null, $layout = null)
     {
-        return $this->_setErrors($code, $errors)->_renderWith($title, $view, $layout);
+        return $this->setErrors($code, $errors)->renderWith($title, $view, $layout);
     }
 
     /**
@@ -116,52 +116,9 @@ abstract class AppController extends Controller
      * @param string|null $layout Layout to use
      * @return \Cake\Http\Response|null
      */
-    protected function _renderWithDialogErrors(int $code, $errors, $view = null, $layout = null)
+    protected function renderWithDialogErrors(int $code, $errors, $view = null, $layout = null)
     {
-        return $this->_setErrors($code, $errors)->_renderWithDialog($view, $layout);
-    }
-
-    /**
-     * 指定のURLへリダイレクトします。
-     *
-     * @param array $options オプション
-     * @param string|array $url A string or array-based URL pointing to another location within the app,
-     *     or an absolute URL
-     * @param int $status HTTP status code (eg: 301)
-     * @return \Cake\Http\Response|null
-     */
-    protected function _redirectWith($options, $url, $status = 302)
-    {
-        if ($options) {
-            $this->set($options);
-        }
-
-        return $this->redirect($url, $status);
-    }
-
-    /**
-     * セッションに書き込みます。
-     *
-     * @param string $key キー
-     * @param mixed $value 値
-     * @return \Gotea\Controller\AppController
-     */
-    protected function _writeToSession($key, $value)
-    {
-        $this->request->session()->write($key, $value);
-
-        return $this;
-    }
-
-    /**
-     * 指定キーの値をセッションから取り出します。
-     *
-     * @param string $key キー
-     * @return mixed
-     */
-    protected function _consumeBySession(string $key)
-    {
-        return $this->request->session()->consume($key);
+        return $this->setErrors($code, $errors)->renderWithDialog($view, $layout);
     }
 
     /**
@@ -171,11 +128,11 @@ abstract class AppController extends Controller
      * @param array|string $errors エラー
      * @return \Gotea\Controller\AppController
      */
-    protected function _setErrors(int $code, $errors)
+    protected function setErrors(int $code, $errors)
     {
         $this->response = $this->response->withStatus($code);
 
-        return $this->_setMessages($errors, 'error');
+        return $this->setMessages($errors, 'error');
     }
 
     /**
@@ -185,7 +142,7 @@ abstract class AppController extends Controller
      * @param string $type メッセージの種類
      * @return \Gotea\Controller\AppController
      */
-    protected function _setMessages($messages, $type = 'info')
+    protected function setMessages($messages, $type = 'info')
     {
         $this->Flash->$type($messages);
 
@@ -198,7 +155,7 @@ abstract class AppController extends Controller
      * @param string $title タイトル
      * @return \Gotea\Controller\AppController
      */
-    protected function _setTitle(string $title)
+    protected function setTitle(string $title)
     {
         return $this->set('title', $title);
     }
@@ -208,7 +165,7 @@ abstract class AppController extends Controller
      *
      * @return \Gotea\Controller\AppController
      */
-    protected function _enableDialogMode()
+    protected function enableDialogMode()
     {
         return $this->set('isDialog', true);
     }

--- a/src/Controller/Component/ApiTrait.php
+++ b/src/Controller/Component/ApiTrait.php
@@ -23,9 +23,9 @@ trait ApiTrait
     public function callApi(string $path, $method = 'get', $data = [], $headers = [], $assoc = true)
     {
         $callMethod = strtolower($method);
-        $url = $this->__getApiPath($path);
+        $url = $this->getApiPath($path);
         $data = (count($data) > 0 ? json_encode($data) : $data);
-        $headers = $this->__createHeaders($headers);
+        $headers = $this->createHeaders($headers);
 
         $http = new Client();
         if (method_exists($http, $callMethod)) {
@@ -56,7 +56,7 @@ trait ApiTrait
      * @param string $path パス
      * @return string 対象APIのURL
      */
-    private function __getApiPath(string $path)
+    private function getApiPath(string $path)
     {
         $url = env('API_URL', 'http://localhost/');
         $length = strlen($url);
@@ -74,7 +74,7 @@ trait ApiTrait
      * @param array $optionHeaders ヘッダに追加設定する情報
      * @return string ヘッダ情報
      */
-    private function __createHeaders($optionHeaders = [])
+    private function createHeaders($optionHeaders = [])
     {
         $headers = [
             'Content-Type' => 'application/json',

--- a/src/Controller/Component/MyAuthComponent.php
+++ b/src/Controller/Component/MyAuthComponent.php
@@ -24,7 +24,7 @@ class MyAuthComponent extends AuthComponent
     public function login(array $credentials)
     {
         // 認証
-        if ($this->__authenticate($credentials)) {
+        if ($this->authenticate($credentials)) {
             return true;
         }
         $this->response = $this->response->withStatus(401);
@@ -53,7 +53,7 @@ class MyAuthComponent extends AuthComponent
      * @param array $credentials 認証情報
      * @return array|false 認証に成功すればそのオブジェクト、失敗すればfalse
      */
-    private function __authenticate(array $credentials)
+    private function authenticate(array $credentials)
     {
         // トークン発行
         $response = $this->callApi('auth', 'post', $credentials);

--- a/src/Controller/NativeQueryController.php
+++ b/src/Controller/NativeQueryController.php
@@ -22,7 +22,7 @@ class NativeQueryController extends AppController
      */
     public function index()
     {
-        return $this->_renderWith('各種情報クエリ更新');
+        return $this->renderWith('各種情報クエリ更新');
     }
 
     /**
@@ -40,7 +40,7 @@ class NativeQueryController extends AppController
         $conn = ConnectionManager::get('default');
         try {
             $count = $conn->transactional(function (ConnectionInterface $conn) use ($queries) {
-                return $this->__executeQueries($conn, $queries);
+                return $this->executeQueries($conn, $queries);
             });
             $this->Flash->info(__('Executed {0} queries', $count));
         } catch (PDOException $e) {
@@ -48,7 +48,7 @@ class NativeQueryController extends AppController
             $this->Flash->error(__('Executing query failed.<br/>Please confirm logfile.'));
         }
 
-        return $this->_renderWith('各種情報クエリ更新', 'index');
+        return $this->renderWith('各種情報クエリ更新', 'index');
     }
 
     /**
@@ -59,7 +59,7 @@ class NativeQueryController extends AppController
      * @return int 更新件数
      * @throws \PDOException
      */
-    private function __executeQueries(ConnectionInterface $conn, $queries)
+    private function executeQueries(ConnectionInterface $conn, $queries)
     {
         $counter = 0;
         foreach ($queries as $query) {

--- a/src/Controller/PlayerRanksController.php
+++ b/src/Controller/PlayerRanksController.php
@@ -21,7 +21,7 @@ class PlayerRanksController extends AppController
      */
     public function index()
     {
-        return $this->_renderWith("段位別棋士数表示");
+        return $this->renderWith("段位別棋士数表示");
     }
 
     /**
@@ -37,9 +37,9 @@ class PlayerRanksController extends AppController
 
         // 保存
         if (!$this->PlayerRanks->save($rank)) {
-            $this->_setErrors(400, $rank->getErrors());
+            $this->setErrors(400, $rank->getErrors());
         } else {
-            $this->_setMessages(__('The rank history is saved'));
+            $this->setMessages(__('The rank history is saved'));
         }
 
         return $this->redirect([
@@ -64,9 +64,9 @@ class PlayerRanksController extends AppController
 
         // 保存
         if (!$this->PlayerRanks->save($rank)) {
-            $this->_setErrors(400, $rank->getErrors());
+            $this->setErrors(400, $rank->getErrors());
         } else {
-            $this->_setMessages(__('The rank history is saved'));
+            $this->setMessages(__('The rank history is saved'));
         }
 
         return $this->redirect([

--- a/src/Controller/PlayersController.php
+++ b/src/Controller/PlayersController.php
@@ -38,7 +38,7 @@ class PlayersController extends AppController
     {
         $this->set('form', new PlayerForm);
 
-        return $this->_renderWith('棋士情報検索');
+        return $this->renderWith('棋士情報検索');
     }
 
     /**
@@ -52,7 +52,7 @@ class PlayersController extends AppController
 
         // バリデーション
         if (!$form->validate($this->request->getParsedBody())) {
-            return $this->_setErrors(400, $form->errors())->setAction('index');
+            return $this->setErrors(400, $form->errors())->setAction('index');
         }
 
         // データを取得
@@ -73,7 +73,7 @@ class PlayersController extends AppController
             $this->set(compact('players'));
         }
 
-        return $this->_renderWith('棋士情報検索', 'index');
+        return $this->renderWith('棋士情報検索', 'index');
     }
 
     /**
@@ -108,7 +108,7 @@ class PlayersController extends AppController
             'validate' => false,
         ]);
 
-        return $this->set(compact('player'))->_renderWithDialog('view');
+        return $this->set(compact('player'))->renderWithDialog('view');
     }
 
     /**
@@ -121,7 +121,7 @@ class PlayersController extends AppController
     {
         $player = $this->Players->findByIdWithRelation($id);
 
-        return $this->set(compact('player'))->_renderWithDialog();
+        return $this->set(compact('player'))->renderWithDialog();
     }
 
     /**
@@ -139,10 +139,10 @@ class PlayersController extends AppController
         if (!$this->Players->save($player)) {
             $this->set(compact('player'));
 
-            return $this->_renderWithDialogErrors(400, $player->getErrors(), 'view');
+            return $this->renderWithDialogErrors(400, $player->getErrors(), 'view');
         }
 
-        $this->_setMessages(__('The player {0} - {1} is saved', $player->id, $player->name));
+        $this->setMessages(__('The player {0} - {1} is saved', $player->id, $player->name));
 
         // 連続作成の場合は新規登録画面へリダイレクト
         if ($this->request->getData('is_continue')) {
@@ -176,10 +176,10 @@ class PlayersController extends AppController
         if (!$this->Players->save($player)) {
             $this->set('player', $player);
 
-            return $this->_renderWithDialogErrors(400, $player->getErrors(), 'view');
+            return $this->renderWithDialogErrors(400, $player->getErrors(), 'view');
         }
 
-        $this->_setMessages(__('The player {0} - {1} is saved', $player->id, $player->name));
+        $this->setMessages(__('The player {0} - {1} is saved', $player->id, $player->name));
 
         return $this->redirect(['_name' => 'view_player', $player->id]);
     }
@@ -191,6 +191,6 @@ class PlayersController extends AppController
      */
     public function ranking()
     {
-        return $this->_renderWith('棋士勝敗ランキング出力');
+        return $this->renderWith('棋士勝敗ランキング出力');
     }
 }

--- a/src/Controller/RetentionHistoriesController.php
+++ b/src/Controller/RetentionHistoriesController.php
@@ -28,9 +28,9 @@ class RetentionHistoriesController extends AppController
 
         // 保存
         if (!$this->RetentionHistories->save($history)) {
-            $this->_setErrors(400, $history->getErrors());
+            $this->setErrors(400, $history->getErrors());
         } else {
-            $this->_setMessages(__('The retention history is saved'));
+            $this->setMessages(__('The retention history is saved'));
         }
 
         return $this->redirect([

--- a/src/Controller/TitleScoresController.php
+++ b/src/Controller/TitleScoresController.php
@@ -30,7 +30,7 @@ class TitleScoresController extends AppController
     {
         $this->set('form', new TitleScoreForm);
 
-        return $this->_renderWith('タイトル勝敗検索', 'index');
+        return $this->renderWith('タイトル勝敗検索', 'index');
     }
 
     /**
@@ -44,7 +44,7 @@ class TitleScoresController extends AppController
 
         // バリデーション
         if (!$form->validate($this->request->getParsedBody())) {
-            return $this->_setErrors(400, $form->errors())->setAction('index');
+            return $this->setErrors(400, $form->errors())->setAction('index');
         }
 
         // リクエストから値を取得
@@ -66,7 +66,7 @@ class TitleScoresController extends AppController
             $this->set(compact('titleScores'));
         }
 
-        return $this->_renderWith('タイトル勝敗検索', 'index');
+        return $this->renderWith('タイトル勝敗検索', 'index');
     }
 
     /**
@@ -84,7 +84,7 @@ class TitleScoresController extends AppController
         ]);
         $this->set(compact('id'))->set(compact('titleScores'));
 
-        return $this->_renderWithDialog('player');
+        return $this->renderWithDialog('player');
     }
 
     /**

--- a/src/Controller/TitlesController.php
+++ b/src/Controller/TitlesController.php
@@ -21,7 +21,7 @@ class TitlesController extends AppController
      */
     public function index()
     {
-        return $this->_renderWith('タイトル情報検索');
+        return $this->renderWith('タイトル情報検索');
     }
 
     /**
@@ -32,12 +32,9 @@ class TitlesController extends AppController
      */
     public function view(int $id)
     {
-        // セッションから入力値が取得できなければIDで取得
-        if (!($title = $this->_consumeBySession('title'))) {
-            $title = $this->Titles->get($id);
-        }
+        $title = $this->Titles->findByIdWithRelation($id);
 
-        return $this->set('title', $title)->_renderWithDialog();
+        return $this->set(compact('title'))->renderWithDialog();
     }
 
     /**
@@ -49,16 +46,16 @@ class TitlesController extends AppController
     public function update(int $id)
     {
         // データ取得
-        $title = $this->Titles->get($id);
+        $title = $this->Titles->findByIdWithRelation($id);
         $this->Titles->patchEntity($title, $this->request->getParsedBody());
 
         // 保存
         if (!$this->Titles->save($title)) {
-            return $this->_writeToSession('title', $title)
-                ->_setErrors(400, $title->getErrors())
-                ->setAction('view', $title->id);
+            $this->set('title', $title);
+
+            return $this->renderWithDialogErrors(400, $title->getErrors(), 'view');
         } else {
-            $this->_setMessages(__('The title {0} - {1} is saved', $title->id, $title->name));
+            $this->setMessages(__('The title {0} - {1} is saved', $title->id, $title->name));
         }
 
         return $this->redirect([

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -48,7 +48,7 @@ class UsersController extends AppController
         $credentials = $this->request->getParsedBody();
         $form = new LoginForm();
         if (!$form->validate($credentials)) {
-            return $this->_setErrors(400, $form->errors())->setAction('index');
+            return $this->setErrors(400, $form->errors())->setAction('index');
         }
 
         // ログイン成功→リダイレクト
@@ -62,7 +62,7 @@ class UsersController extends AppController
         }
 
         // ログイン失敗
-        return $this->_setErrors(401, __('Authentication failed'))->setAction('index');
+        return $this->setErrors(401, __('Authentication failed'))->setAction('index');
     }
 
     /**

--- a/src/Model/Entity/AppEntity.php
+++ b/src/Model/Entity/AppEntity.php
@@ -3,7 +3,6 @@
 namespace Gotea\Model\Entity;
 
 use Cake\ORM\Entity;
-use Cake\ORM\TableRegistry;
 
 /**
  * アプリケーションの共通エンティティ
@@ -27,20 +26,6 @@ class AppEntity extends Entity
     ];
 
     /**
-     * {@inheritDoc}
-     */
-    // public function &get($property)
-    // {
-    //     $value = parent::get($property);
-    //     // 配列ならCollectionに変換
-    //     if (is_array($value)) {
-    //         $value = collection($value);
-    //     }
-
-    //     return $value;
-    // }
-
-    /**
      * バリデーションエラー一覧を取得します。
      * フォーマットが「フィールド => [定義 => メッセージ]」となっているため、メッセージのみ抽出
      *
@@ -51,39 +36,5 @@ class AppEntity extends Entity
         return array_values(collection($this->getErrors())->map(function ($error) {
             return array_shift($error);
         })->toArray());
-    }
-
-    /**
-     * 所属國を取得します。
-     *
-     * @param mixed $value 値
-     * @return Country
-     */
-    protected function _getCountry($value)
-    {
-        if ($value) {
-            return $value;
-        }
-
-        $result = TableRegistry::get('Countries')->get($this->country_id);
-
-        return $this->country = $result;
-    }
-
-    /**
-     * 段位を取得します。
-     *
-     * @param mixed $value 値
-     * @return Rank
-     */
-    protected function _getRank($value)
-    {
-        if ($value) {
-            return $value;
-        }
-
-        $result = TableRegistry::get('Ranks')->get($this->rank_id);
-
-        return $this->rank = $result;
     }
 }

--- a/src/Model/Entity/CountryTrait.php
+++ b/src/Model/Entity/CountryTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gotea\Model\Entity;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * 所属国の操作クラス
+ */
+trait CountryTrait
+{
+    /**
+     * 所属國を取得します。
+     *
+     * @param \Gotea\Model\Entity\Country|null $country 所属国オブジェクト
+     * @return \Gotea\Model\Entity\Country
+     */
+    protected function _getCountry($country)
+    {
+        if ($country) {
+            return $country;
+        }
+
+        if (!$this->country_id) {
+            return null;
+        }
+
+        $result = TableRegistry::get('Countries')->get($this->country_id);
+
+        return $this->country = $result;
+    }
+}

--- a/src/Model/Entity/Organization.php
+++ b/src/Model/Entity/Organization.php
@@ -7,4 +7,5 @@ namespace Gotea\Model\Entity;
  */
 class Organization extends AppEntity
 {
+    use CountryTrait;
 }

--- a/src/Model/Entity/Player.php
+++ b/src/Model/Entity/Player.php
@@ -11,6 +11,9 @@ use Cake\Routing\Router;
  */
 class Player extends AppEntity
 {
+    use CountryTrait;
+    use RankTrait;
+
     /**
      * 入力フォーム用の入段日を取得します。
      *
@@ -229,7 +232,7 @@ class Player extends AppEntity
      */
     public function win($year = null, $world = false)
     {
-        return $this->__show('win', $year, $world);
+        return $this->show('win', $year, $world);
     }
 
     /**
@@ -241,7 +244,7 @@ class Player extends AppEntity
      */
     public function lose($year = null, $world = false)
     {
-        return $this->__show('lose', $year, $world);
+        return $this->show('lose', $year, $world);
     }
 
     /**
@@ -253,7 +256,7 @@ class Player extends AppEntity
      */
     public function draw($year = null, $world = false)
     {
-        return $this->__show('draw', $year, $world);
+        return $this->show('draw', $year, $world);
     }
 
     /**
@@ -264,13 +267,13 @@ class Player extends AppEntity
      * @param bool $world 対象が国際棋戦かどうか
      * @return int|string 対象数
      */
-    private function __show($type, $year = null, $world = false)
+    private function show($type, $year = null, $world = false)
     {
         if ($year === null) {
             $year = FrozenDate::now()->year;
         }
         $scores = collection($this->title_score_details);
-        $score = $scores->filter(function ($item, $key) use ($year) {
+        $score = $scores->filter(function ($item) use ($year) {
             return (int)$item->player_id === $this->id
                 && (int)$item->target_year === $year;
         })->first();

--- a/src/Model/Entity/PlayerRank.php
+++ b/src/Model/Entity/PlayerRank.php
@@ -18,4 +18,6 @@ use Cake\ORM\Entity;
  */
 class PlayerRank extends AppEntity
 {
+    use PlayerTrait;
+    use RankTrait;
 }

--- a/src/Model/Entity/PlayerScore.php
+++ b/src/Model/Entity/PlayerScore.php
@@ -7,6 +7,9 @@ namespace Gotea\Model\Entity;
  */
 class PlayerScore extends AppEntity
 {
+    use PlayerTrait;
+    use RankTrait;
+
     /**
      * ランキング表示用の名前を取得します。
      *

--- a/src/Model/Entity/PlayerTrait.php
+++ b/src/Model/Entity/PlayerTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gotea\Model\Entity;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * 棋士の操作クラス
+ */
+trait PlayerTrait
+{
+    /**
+     * 棋士を取得します。
+     *
+     * @param \Gotea\Model\Entity\Player|null $player 棋士オブジェクト
+     * @return \Gotea\Model\Entity\Player
+     */
+    protected function _getPlayer($player)
+    {
+        if ($player) {
+            return $player;
+        }
+
+        if (!$this->player_id) {
+            return null;
+        }
+
+        $result = TableRegistry::get('Players')->get($this->player_id);
+
+        return $this->player = $result;
+    }
+}

--- a/src/Model/Entity/RankTrait.php
+++ b/src/Model/Entity/RankTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gotea\Model\Entity;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * 段位の操作クラス
+ */
+trait RankTrait
+{
+    /**
+     * 段位を取得します。
+     *
+     * @param \Gotea\Model\Entity\Rank|null $rank 段位オブジェクト
+     * @return \Gotea\Model\Entity\Rank
+     */
+    protected function _getRank($rank)
+    {
+        if ($rank) {
+            return $rank;
+        }
+
+        if (!$this->rank_id) {
+            return null;
+        }
+
+        $result = TableRegistry::get('Ranks')->get($this->rank_id);
+
+        return $this->rank = $result;
+    }
+}

--- a/src/Model/Entity/RetentionHistory.php
+++ b/src/Model/Entity/RetentionHistory.php
@@ -9,26 +9,8 @@ use Cake\ORM\TableRegistry;
  */
 class RetentionHistory extends AppEntity
 {
-    /**
-     * 棋士を取得します。
-     *
-     * @param mixed $value 値
-     * @return Player|null
-     */
-    protected function _getPlayer($value)
-    {
-        if ($value) {
-            return $value;
-        }
-
-        if (!$this->player_id) {
-            return null;
-        }
-
-        $result = TableRegistry::get('Players')->get($this->player_id);
-
-        return $this->player = $result;
-    }
+    use PlayerTrait;
+    use RankTrait;
 
     /**
      * 団体戦判定結果を取得します。

--- a/src/Model/Entity/Title.php
+++ b/src/Model/Entity/Title.php
@@ -10,26 +10,7 @@ use Cake\ORM\TableRegistry;
  */
 class Title extends AppEntity
 {
-    /**
-     * タイトル獲得履歴を取得します。
-     *
-     * @param mixed $value 更新値
-     * @return mixed タイトル獲得履歴
-     */
-    protected function _getRetentionHistories($value)
-    {
-        if ($value) {
-            return $value;
-        }
-
-        if (!$this->id) {
-            return collection([]);
-        }
-
-        $result = TableRegistry::get('RetentionHistories')->findHistoriesByTitle($this->id);
-
-        return $this->retention_histories = $result;
-    }
+    use CountryTrait;
 
     /**
      * 現在の保持情報を取得します。
@@ -38,7 +19,7 @@ class Title extends AppEntity
      */
     protected function _getNowRetention()
     {
-        return collection($this->retention_histories)->filter(function ($item, $key) {
+        return collection($this->retention_histories)->filter(function ($item) {
             return $item->holding === $this->holding;
         })->first();
     }
@@ -50,7 +31,7 @@ class Title extends AppEntity
      */
     protected function _getHistories()
     {
-        return collection($this->retention_histories)->filter(function ($item, $key) {
+        return collection($this->retention_histories)->filter(function ($item) {
             return $item->holding < $this->holding;
         });
     }
@@ -59,9 +40,9 @@ class Title extends AppEntity
      * HTMLファイル修正日を設定します。
      *
      * @param mixed $newValue 更新値
-     * @return \Cake\I18n\FrozenDate
+     * @return \Cake\I18n\FrozenDate|null
      */
-    protected function _setHtmlFileModified($newValue)
+    protected function _setHtmlFileModified($newValue = null)
     {
         if ($newValue && !($newValue instanceof FrozenDate)) {
             return FrozenDate::parseDate($newValue, 'YYYY/MM/dd');

--- a/src/Model/Entity/TitleScore.php
+++ b/src/Model/Entity/TitleScore.php
@@ -19,6 +19,8 @@ namespace Gotea\Model\Entity;
  */
 class TitleScore extends AppEntity
 {
+    use CountryTrait;
+
     /**
      * 指定した棋士に合致するかを判定します。
      *

--- a/src/Model/Entity/TitleScoreDetail.php
+++ b/src/Model/Entity/TitleScoreDetail.php
@@ -19,6 +19,9 @@ namespace Gotea\Model\Entity;
  */
 class TitleScoreDetail extends AppEntity
 {
+    use PlayerTrait;
+    use RankTrait;
+
     /**
      * ランキング表示用の名前を取得します。
      *

--- a/src/Model/Entity/UpdatedPoint.php
+++ b/src/Model/Entity/UpdatedPoint.php
@@ -7,4 +7,5 @@ namespace Gotea\Model\Entity;
  */
 class UpdatedPoint extends AppEntity
 {
+    use CountryTrait;
 }

--- a/src/Model/Table/PlayersTable.php
+++ b/src/Model/Table/PlayersTable.php
@@ -147,13 +147,13 @@ class PlayersTable extends AppTable
             $query->where(['Players.sex' => $sex]);
         }
         if (($name = trim(Hash::get($data, 'name')))) {
-            $query->where(['OR' => $this->__createLikeParams('name', $name)]);
+            $query->where(['OR' => $this->createLikeParams('name', $name)]);
         }
         if (($nameEnglish = trim(Hash::get($data, 'name_english')))) {
-            $query->where(['OR' => $this->__createLikeParams('name_english', $nameEnglish)]);
+            $query->where(['OR' => $this->createLikeParams('name_english', $nameEnglish)]);
         }
         if (($nameOther = trim(Hash::get($data, 'name_other')))) {
-            $query->where(['OR' => $this->__createLikeParams('name_other', $nameOther)]);
+            $query->where(['OR' => $this->createLikeParams('name_other', $nameOther)]);
         }
         if (($joinedFrom = Hash::get($data, 'joined_from')) > 0) {
             $query->where(['SUBSTR(Players.joined, 1, 4) >=' => sprintf('%04d', $joinedFrom)]);
@@ -221,7 +221,7 @@ class PlayersTable extends AppTable
      * @param string $input 入力値
      * @return array
      */
-    private function __createLikeParams(string $fieldName, string $input)
+    private function createLikeParams(string $fieldName, string $input)
     {
         $whereClause = [];
         $params = explode(" ", $input);

--- a/src/Model/Table/TitleScoreDetailsTable.php
+++ b/src/Model/Table/TitleScoreDetailsTable.php
@@ -117,7 +117,7 @@ class TitleScoreDetailsTable extends AppTable
     public function findRanking(Country $country, int $limit, Date $started, Date $ended)
     {
         // 旧方式
-        if ($this->__isOldRanking($started->year)) {
+        if ($this->isOldRanking($started->year)) {
             $playerScores = TableRegistry::get('PlayerScores');
 
             return $playerScores->findRanking($country, $started->year, $limit);
@@ -180,7 +180,7 @@ class TitleScoreDetailsTable extends AppTable
     public function findRecent(Country $country, Date $started, Date $ended)
     {
         // 旧方式
-        if ($this->__isOldRanking($started->year)) {
+        if ($this->isOldRanking($started->year)) {
             $points = TableRegistry::get('UpdatedPoints');
 
             return $points->findRecent($country, $started->year);
@@ -209,7 +209,7 @@ class TitleScoreDetailsTable extends AppTable
      * @param int $targetYear 対象年度
      * @return bool
      */
-    private function __isOldRanking(int $targetYear) : bool
+    private function isOldRanking(int $targetYear) : bool
     {
         return ($targetYear < 2017);
     }

--- a/src/Model/Table/TitlesTable.php
+++ b/src/Model/Table/TitlesTable.php
@@ -23,6 +23,7 @@ class TitlesTable extends AppTable
         // タイトル保持情報
         $this->hasMany('RetentionHistories')
             ->setSort([
+                'RetentionHistories.target_year' => 'DESC',
                 'RetentionHistories.holding' => 'DESC'
             ]);
         // 所属国マスタ
@@ -47,6 +48,23 @@ class TitlesTable extends AppTable
             ->maxLength('name', 30)
             ->maxLength('name_english', 30)
             ->date('html_file_modified', 'y/m/d');
+    }
+
+    /**
+     * IDに合致する棋士と関連データを取得します。
+     *
+     * @param int $id 検索キー
+     * @return \Gotea\Model\Entity\Title 棋士と関連データ
+     * @throws \Cake\Datasource\Exception\InvalidPrimaryKeyException
+     */
+    public function findByIdWithRelation(int $id)
+    {
+        return $this->get($id, [
+            'contain' => [
+                'Countries',
+                'RetentionHistories',
+            ],
+        ]);
     }
 
     /**

--- a/src/View/Helper/MyFlashHelper.php
+++ b/src/View/Helper/MyFlashHelper.php
@@ -8,9 +8,6 @@ use Cake\View\Helper\FlashHelper;
  */
 class MyFlashHelper extends FlashHelper
 {
-    private $_prefix = '<li>';
-    private $_suffix = '</li>';
-
     /**
      * エラーメッセージ単位に配列形式で取得する。
      *
@@ -30,6 +27,5 @@ class MyFlashHelper extends FlashHelper
         }
 
         return h(json_encode($out));
-        // return $this->_prefix.implode($this->_suffix.$this->_prefix, $out).$this->_suffix;
     }
 }

--- a/tests/TestCase/Controller/Api/ApiTestCase.php
+++ b/tests/TestCase/Controller/Api/ApiTestCase.php
@@ -13,7 +13,7 @@ abstract class ApiTestCase extends IntegrationTestCase
      *
      * @var array
      */
-    private $__emptyResponse = [
+    private $emptyResponse = [
         'response' => [],
     ];
 
@@ -22,7 +22,7 @@ abstract class ApiTestCase extends IntegrationTestCase
      *
      * @var array
      */
-    private $__notFoundResponse = [
+    private $notFoundResponse = [
         'response' => [
             'code' => 404,
             'message' => 'Not Found',
@@ -53,7 +53,7 @@ abstract class ApiTestCase extends IntegrationTestCase
      */
     public function getEmptyResponse()
     {
-        return $this->getCompareJsonResponse($this->__emptyResponse);
+        return $this->getCompareJsonResponse($this->emptyResponse);
     }
 
     /**
@@ -63,7 +63,7 @@ abstract class ApiTestCase extends IntegrationTestCase
      */
     public function getNotFoundResponse()
     {
-        return $this->getCompareJsonResponse($this->__notFoundResponse);
+        return $this->getCompareJsonResponse($this->notFoundResponse);
     }
 
     /**

--- a/tests/TestCase/Controller/AppTestCase.php
+++ b/tests/TestCase/Controller/AppTestCase.php
@@ -13,7 +13,7 @@ abstract class AppTestCase extends IntegrationTestCase
      *
      * @return void
      */
-    protected function _createSession()
+    protected function createSession()
     {
         $this->session([
             'Auth' => [

--- a/tests/TestCase/Controller/PlayerRanksControllerTest.php
+++ b/tests/TestCase/Controller/PlayerRanksControllerTest.php
@@ -36,7 +36,7 @@ class PlayerRanksControllerTest extends AppTestCase
     {
         parent::setUp();
         $this->PlayerRanks = TableRegistry::get('PlayerRanks');
-        $this->_createSession();
+        $this->createSession();
     }
 
     /**

--- a/tests/TestCase/Controller/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/PlayersControllerTest.php
@@ -44,7 +44,7 @@ class PlayersControllerTest extends AppTestCase
     {
         parent::setUp();
         $this->Players = TableRegistry::get('Players');
-        $this->_createSession();
+        $this->createSession();
     }
 
     /**

--- a/tests/TestCase/Controller/RetentionHistoriesControllerTest.php
+++ b/tests/TestCase/Controller/RetentionHistoriesControllerTest.php
@@ -40,7 +40,7 @@ class RetentionHistoriesControllerTest extends AppTestCase
     {
         parent::setUp();
         $this->RetentionHistories = TableRegistry::get('RetentionHistories');
-        $this->_createSession();
+        $this->createSession();
     }
 
     /**

--- a/tests/TestCase/Controller/TitleScoresControllerTest.php
+++ b/tests/TestCase/Controller/TitleScoresControllerTest.php
@@ -26,7 +26,7 @@ class TitleScoresControllerTest extends AppTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_createSession();
+        $this->createSession();
     }
 
     /**

--- a/tests/TestCase/Controller/TitlesControllerTest.php
+++ b/tests/TestCase/Controller/TitlesControllerTest.php
@@ -40,7 +40,7 @@ class TitlesControllerTest extends AppTestCase
     {
         parent::setUp();
         $this->Titles = TableRegistry::get('Titles');
-        $this->_createSession();
+        $this->createSession();
     }
 
     /**

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -109,7 +109,7 @@ class UsersControllerTest extends AppTestCase
      */
     public function testLoggedTop()
     {
-        $this->_createSession();
+        $this->createSession();
         $this->get('/');
         $this->assertRedirect(['_name' => 'players']);
     }
@@ -121,7 +121,7 @@ class UsersControllerTest extends AppTestCase
      */
     public function testLogout()
     {
-        $this->_createSession();
+        $this->createSession();
         $this->get('/logout');
         $this->assertResponseCode(302);
     }


### PR DESCRIPTION
Cake2 の規約にはアンダースコア始まりにするようにという記載があるが、Cake3にはない。

Cake2 - https://book.cakephp.org/2.0/ja/contributing/cakephp-coding-conventions.html#visibility
Cake3 - https://book.cakephp.org/3.0/ja/contributing/cakephp-coding-conventions.html#visibility

アクセス識別子がある現状では、アクセス識別子で判断するのが適切であるため、アプリケーション固有のコードでは「_」を使わない。
※Cakeのコア部分では未だ多く使われているため、これらを利用するは踏襲する。