### PR TITLE
merges #495 

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -127,6 +127,7 @@ Router::scope('/', function (RouteBuilder $routes) {
 
     // API
     $routes->prefix('Api', function (RouteBuilder $routes) {
+        $routes->setExtensions(['json']);
 
         $routes->get('/years', ['controller' => 'Years', 'action' => 'index'], 'api_years');
 

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -15,6 +15,8 @@ use PDOException;
  */
 class ErrorController extends BaseErrorController
 {
+    use JsonResponseTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/src/Controller/JsonResponseTrait.php
+++ b/src/Controller/JsonResponseTrait.php
@@ -25,12 +25,16 @@ trait JsonResponseTrait
     /**
      * エラーレスポンスを生成します。
      *
-     * @param int $code ステータスコード
+     * @param int|null $code ステータスコード
      * @param string|null $message メッセージ
      * @return \Cake\Http\Response
      */
-    public function renderError($code = 500, $message = null)
+    public function renderError(?int $code = 500, ?string $message = null)
     {
+        if ($code === 0) {
+            $code = 500;
+        }
+
         $this->setResponse($this->getResponse()->withStatus($code));
 
         if (!$message) {

--- a/src/Controller/JsonResponseTrait.php
+++ b/src/Controller/JsonResponseTrait.php
@@ -26,10 +26,10 @@ trait JsonResponseTrait
      * エラーレスポンスを生成します。
      *
      * @param int|null $code ステータスコード
-     * @param string|null $message メッセージ
+     * @param string|array|null $message メッセージ
      * @return \Cake\Http\Response
      */
-    public function renderError(?int $code = 500, ?string $message = null)
+    public function renderError(?int $code = 500, $message = null)
     {
         if ($code === 0) {
             $code = 500;

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -19,7 +19,12 @@ class AppExceptionRenderer extends ExceptionRenderer
      */
     public function render()
     {
-        $this->_getController()->rollback($this->error);
+        $this->controller->rollback($this->error);
+
+        // JSONリクエストの場合
+        if ($this->controller->getRequest()->is('json')) {
+            return $this->controller->renderError($this->error->getCode());
+        }
 
         return parent::render();
     }


### PR DESCRIPTION
### 概要

- JSONリクエストでエラー発生時、エラーJSONを返却する

### 対応内容

- `Accept: application/json`がヘッダに含まれていた場合、エラー発生時もJSONを返却するよう修正
