### PR TITLE
merges #657

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -29,7 +29,6 @@ abstract class AppController extends Controller
         $this->forceSSL();
         $this->loadComponent('Flash');
         $this->loadComponent('Auth', [
-            'className' => 'MyAuth',
             'loginAction' => [
                 '_name' => 'top',
             ],

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -2,7 +2,7 @@
 
 namespace Gotea\Controller\Component;
 
-use Cake\Controller\Component\AuthComponent;
+use Cake\Controller\Component\AuthComponent as BaseAuthComponent;
 use Cake\Log\Log;
 
 /**
@@ -11,7 +11,7 @@ use Cake\Log\Log;
  * @author  Kazuki Kamizuru
  * @since   2016/12/25
  */
-class MyAuthComponent extends AuthComponent
+class AuthComponent extends BaseAuthComponent
 {
     use ApiTrait;
 
@@ -27,7 +27,7 @@ class MyAuthComponent extends AuthComponent
         if ($this->authenticate($credentials)) {
             return true;
         }
-        $this->setResponse($this->getResponse()->withStatus(401));
+        $this->getController()->setResponse($this->getController()->getResponse()->withStatus(401));
 
         return false;
     }


### PR DESCRIPTION
### 概要

- 認証エラー時のバグ修正

### 対応内容

- `setResponse()` および `getResponse()` はコンポーネントに存在しないので `getController()` でコントローラを取得してから前述の関数を利用するよう修正