### PR TITLE
merges #708

### DIFF
--- a/src/Model/Table/TitlesTable.php
+++ b/src/Model/Table/TitlesTable.php
@@ -51,11 +51,12 @@ class TitlesTable extends AppTable
             ->alphaNumeric('name_english')
             ->add('html_file_name', 'custom', [
                 'rule' => function ($value) {
-                    return (bool)preg_match('/^[a-zA-Z0-9\(\)\'\-\/\s]+$/', $value);
+                    return (bool) preg_match('/^[a-zA-Z0-9\(\)\'\-\/\s]+$/', $value);
                 },
             ])
             ->maxLength('name', 30)
-            ->maxLength('name_english', 30)
+            ->maxLength('name_english', 60)
+            ->maxLength('html_file_name', 30)
             ->date('html_file_modified', 'y/m/d');
     }
 

--- a/src/Model/Table/TitlesTable.php
+++ b/src/Model/Table/TitlesTable.php
@@ -51,7 +51,7 @@ class TitlesTable extends AppTable
             ->alphaNumeric('name_english')
             ->add('html_file_name', 'custom', [
                 'rule' => function ($value) {
-                    return (bool) preg_match('/^[a-zA-Z0-9\(\)\'\-\/\s]+$/', $value);
+                    return (bool)preg_match('/^[a-zA-Z0-9\(\)\'\-\/\s]+$/', $value);
                 },
             ])
             ->maxLength('name', 30)

--- a/tests/Fixture/TitlesFixture.php
+++ b/tests/Fixture/TitlesFixture.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Gotea\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
@@ -20,10 +21,10 @@ class TitlesFixture extends TestFixture
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
         'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '所属国ID', 'precision' => null, 'autoIncrement' => null],
         'name' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル名', 'precision' => null, 'fixed' => null],
-        'name_english' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル名（英語）', 'precision' => null, 'fixed' => null],
+        'name_english' => ['type' => 'string', 'length' => 60, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル名（英語）', 'precision' => null, 'fixed' => null],
         'holding' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '期', 'precision' => null, 'autoIncrement' => null],
         'sort_order' => ['type' => 'integer', 'length' => 2, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '並び順', 'precision' => null, 'autoIncrement' => null],
-        'html_file_name' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'htmlファイル名', 'precision' => null, 'fixed' => null],
+        'html_file_name' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'htmlファイル名', 'precision' => null, 'fixed' => null],
         'html_file_modified' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => 'htmlファイル修正日', 'precision' => null],
         'remarks' => ['type' => 'string', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'その他備考', 'precision' => null, 'fixed' => null],
         'is_team' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '団体戦判定', 'precision' => null],

--- a/tests/TestCase/Model/Table/TitlesTableTest.php
+++ b/tests/TestCase/Model/Table/TitlesTableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Gotea\Test\TestCase\Model\Table;
 
 use Cake\I18n\FrozenDate;
@@ -124,13 +125,19 @@ class TitlesTableTest extends TestCase
         // maxLength
         // name
         $data = $params;
-        $data['name'] = '1234567890123456789012345678901';
+        $data['name'] = substr(bin2hex(random_bytes(31)), 0, 31);
         $result = $this->Titles->newEntity($data);
         $this->assertNotEmpty($result->getErrors());
 
         // name_english
         $data = $params;
-        $data['name_english'] = '1234567890123456789012345678901';
+        $data['name_english'] = substr(bin2hex(random_bytes(61)), 0, 61);
+        $result = $this->Titles->newEntity($data);
+        $this->assertNotEmpty($result->getErrors());
+
+        // html_file_name
+        $data = $params;
+        $data['html_file_name'] = substr(bin2hex(random_bytes(31)), 0, 31);
         $result = $this->Titles->newEntity($data);
         $this->assertNotEmpty($result->getErrors());
 


### PR DESCRIPTION
### 概要

- titles テーブルのカラム定義変更

### 対応内容

- タイトル名（英語）を上限60文字に
- HTMLファイル名を上限30文字に
