### PR TITLE
cakephp 3.8 にアップデート

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run: composer install -n --prefer-dist
       - save_cache:
           <<: *save_composer_cache
-      - run: composer phpcs
+      - run: composer cs-check
 
   test:
     docker:
@@ -70,7 +70,7 @@ jobs:
       - save_cache:
           <<: *save_composer_cache
       - run: cp .env.example .env
-      - run: composer phpunit
+      - run: composer test
 
   deploy:
     docker:

--- a/composer.json
+++ b/composer.json
@@ -1,55 +1,63 @@
 {
-    "name": "gotoeveryone/gotea",
-    "description": "IGO players and titles management system.",
-    "homepage": "https://gotoeveryone.k2ss.info",
-    "authors": [
-        {
-            "name": "Kazuki Kamizuru",
-            "email": "webmaster@k2ss.info",
-            "homepage": "https://k2ss.info/",
-            "role": "Administrator"
-        }
+  "name": "gotoeveryone/gotea",
+  "description": "IGO players and titles management system.",
+  "homepage": "https://gotoeveryone.k2ss.info",
+  "authors": [
+    {
+      "name": "Kazuki Kamizuru",
+      "email": "webmaster@k2ss.info",
+      "homepage": "https://k2ss.info/",
+      "role": "Administrator"
+    }
+  ],
+  "type": "project",
+  "license": "MIT",
+  "require": {
+    "php": "^7.1.3",
+    "cakephp/cakephp": "3.8.*",
+    "mobiledetect/mobiledetectlib": "^2.8",
+    "cakephp/migrations": "^1.6",
+    "cakephp/plugin-installer": "^1.0",
+    "vlucas/phpdotenv": "^2.4",
+    "fabpot/goutte": "^3.2",
+    "gotoeveryone/cake-parts": "0.0.*"
+  },
+  "require-dev": {
+    "psy/psysh": "@stable",
+    "cakephp/debug_kit": "~3.0",
+    "cakephp/bake": "~1.1",
+    "phpunit/phpunit": "^6.1",
+    "cakephp/cakephp-codesniffer": "^3.0"
+  },
+  "suggest": {
+    "phpunit/phpunit": "Allows automated tests to be run without system-wide install.",
+    "cakephp/cakephp-codesniffer": "Allows to check the code against the coding standards used in CakePHP."
+  },
+  "autoload": {
+    "psr-4": {
+      "Gotea\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Gotea\\Test\\": "tests",
+      "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+    }
+  },
+  "scripts": {
+    "post-install-cmd": "Gotea\\Console\\Installer::postInstall",
+    "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
+    "check": [
+      "@test",
+      "@cs-check"
     ],
-    "type": "project",
-    "license": "MIT",
-    "require": {
-        "php": "^7.1.3",
-        "cakephp/cakephp": "3.7.*",
-        "mobiledetect/mobiledetectlib": "^2.8",
-        "cakephp/migrations": "^1.6",
-        "cakephp/plugin-installer": "^1.0",
-        "vlucas/phpdotenv": "^2.4",
-        "fabpot/goutte": "^3.2",
-        "gotoeveryone/cake-parts": "0.0.*"
-    },
-    "require-dev": {
-        "psy/psysh": "@stable",
-        "cakephp/debug_kit": "~3.0",
-        "cakephp/bake": "~1.1",
-        "phpunit/phpunit": "^6.1",
-        "cakephp/cakephp-codesniffer": "^3.0"
-    },
-    "suggest": {
-        "phpunit/phpunit": "Allows automated tests to be run without system-wide install.",
-        "cakephp/cakephp-codesniffer": "Allows to check the code against the coding standards used in CakePHP."
-    },
-    "autoload": {
-        "psr-4": {
-            "Gotea\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Gotea\\Test\\": "tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
-        }
-    },
-    "scripts": {
-        "post-install-cmd": "Gotea\\Console\\Installer::postInstall",
-        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
-        "phpcs": "phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "phpunit": "phpunit"
-    },
-    "minimum-stability": "stable",
-    "prefer-stable": true
+    "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
+    "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
+    "test": "phpunit --colors=always"
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "config": {
+    "sort-packages": true
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38ef5c1de47955a2647d14e581243981",
+    "content-hash": "b70e37a9650466e40629e48852d62f03",
     "packages": [
         {
             "name": "aura/intl",
@@ -54,16 +54,16 @@
         },
         {
             "name": "cakephp/cakephp",
-            "version": "3.7.5",
+            "version": "3.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "0e63c784a61baf65d97177b07bd5f50574218745"
+                "reference": "34833a0c02fc1fc21e27ceb69cf7b4f7c131a3cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/0e63c784a61baf65d97177b07bd5f50574218745",
-                "reference": "0e63c784a61baf65d97177b07bd5f50574218745",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/34833a0c02fc1fc21e27ceb69cf7b4f7c131a3cc",
+                "reference": "34833a0c02fc1fc21e27ceb69cf7b4f7c131a3cc",
                 "shasum": ""
             },
             "require": {
@@ -139,30 +139,29 @@
                 "rapid-development",
                 "validation"
             ],
-            "time": "2019-03-14T01:47:14+00:00"
+            "time": "2019-11-07T01:11:43+00:00"
         },
         {
             "name": "cakephp/chronos",
-            "version": "1.2.4",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/chronos.git",
-                "reference": "ebda7326d4a65e53bc5bb915ebbbeee98f1926b0"
+                "reference": "ba2bab98849e7bf29b02dd634ada49ab36472959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/chronos/zipball/ebda7326d4a65e53bc5bb915ebbbeee98f1926b0",
-                "reference": "ebda7326d4a65e53bc5bb915ebbbeee98f1926b0",
+                "url": "https://api.github.com/repos/cakephp/chronos/zipball/ba2bab98849e7bf29b02dd634ada49ab36472959",
+                "reference": "ba2bab98849e7bf29b02dd634ada49ab36472959",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|^7"
+                "php": ">=5.6"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1",
                 "cakephp/cakephp-codesniffer": "^3.0",
                 "phpbench/phpbench": "@dev",
-                "phpstan/phpstan": "^0.6.4",
                 "phpunit/phpunit": "<6.0 || ^7.0"
             },
             "type": "library",
@@ -196,7 +195,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2019-02-11T02:08:31+00:00"
+            "time": "2019-11-30T02:33:19+00:00"
         },
         {
             "name": "cakephp/migrations",
@@ -674,16 +673,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -692,7 +691,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -717,7 +716,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -1511,16 +1510,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.8.6",
+            "version": "1.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "20da13beba0dde8fb648be3cc19765732790f46e"
+                "reference": "a85e67b86e9b8520d07e6415fcbcb8391b44a75b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/20da13beba0dde8fb648be3cc19765732790f46e",
-                "reference": "20da13beba0dde8fb648be3cc19765732790f46e",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/a85e67b86e9b8520d07e6415fcbcb8391b44a75b",
+                "reference": "a85e67b86e9b8520d07e6415fcbcb8391b44a75b",
                 "shasum": ""
             },
             "require": {
@@ -1540,9 +1539,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev",
-                    "dev-develop": "1.9.x-dev",
-                    "dev-release-2.0": "2.0.x-dev"
+                    "dev-release-1.8": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -1571,7 +1568,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-09-05T19:29:37+00:00"
+            "time": "2019-08-06T17:53:53+00:00"
         }
     ],
     "packages-dev": [

--- a/config/app.php
+++ b/config/app.php
@@ -1,4 +1,12 @@
 <?php
+
+use Cake\Cache\Engine\FileEngine;
+use Cake\Database\Connection;
+use Cake\Database\Driver\Mysql;
+use Cake\Log\Engine\FileLog;
+use Cake\Mailer\Transport\SmtpTransport;
+use Gotea\Error\AppExceptionRenderer;
+
 return [
     /**
      * Debug Level:
@@ -65,7 +73,7 @@ return [
      *   You should treat it as extremely sensitive data.
      */
     'Security' => [
-        'salt' => env('SECURITY_SALT', '__SALT__'),
+        'salt' => env('SECURITY_SALT'),
     ],
 
     /**
@@ -86,7 +94,7 @@ return [
      */
     'Cache' => [
         'default' => [
-            'className' => 'File',
+            'className' => FileEngine::class,
             'path' => CACHE,
             'url' => env('CACHE_DEFAULT_URL', null),
         ],
@@ -98,7 +106,7 @@ return [
          * If you set 'className' => 'Null' core cache will be disabled.
          */
         '_cake_core_' => [
-            'className' => 'Cake\Cache\Engine\FileEngine',
+            'className' => FileEngine::class,
             'prefix' => 'gotea_cake_core_',
             'path' => CACHE . 'persistent/',
             'serialize' => true,
@@ -113,7 +121,7 @@ return [
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          */
         '_cake_model_' => [
-            'className' => 'Cake\Cache\Engine\FileEngine',
+            'className' => FileEngine::class,
             'prefix' => 'gotea_cake_model_',
             'path' => CACHE . 'models/',
             'serialize' => true,
@@ -127,7 +135,7 @@ return [
          * Duration will be set to '+2 seconds' in bootstrap.php when debug = true
          */
         '_cake_routes_' => [
-            'className' => 'Cake\Cache\Engine\FileEngine',
+            'className' => FileEngine::class,
             'prefix' => 'gotea_cake_routes_',
             'path' => CACHE,
             'serialize' => true,
@@ -167,7 +175,7 @@ return [
      */
     'Error' => [
         'errorLevel' => E_ALL & ~E_DEPRECATED,
-        'exceptionRenderer' => 'Gotea\Error\AppExceptionRenderer',
+        'exceptionRenderer' => AppExceptionRenderer::class,
         'skipLog' => [],
         'log' => true,
         'trace' => true,
@@ -194,7 +202,7 @@ return [
      */
     'EmailTransport' => [
         'default' => [
-            'className' => 'Smtp',
+            'className' => SmtpTransport::class,
             // The following keys are used in SMTP transports
             'host' => env('EMAIL_HOST', 'localhost'),
             'port' => env('EMAIL_PORT', 25),
@@ -243,8 +251,8 @@ return [
      */
     'Datasources' => [
         'default' => [
-            'className' => 'Cake\Database\Connection',
-            'driver' => 'Cake\Database\Driver\Mysql',
+            'className' => Connection::class,
+            'driver' => Mysql::class,
             'persistent' => false,
             'host' => env('DB_HOST', 'localhost'),
             /**
@@ -288,8 +296,8 @@ return [
          * The test connection is used during the test suite.
          */
         'test' => [
-            'className' => 'Cake\Database\Connection',
-            'driver' => 'Cake\Database\Driver\Mysql',
+            'className' => Connection::class,
+            'driver' => Mysql::class,
             'persistent' => false,
             'host' => env('DB_TEST_HOST', 'localhost'),
             'port' => env('DB_TEST_PORT', 3306),
@@ -311,7 +319,7 @@ return [
      */
     'Log' => [
         'debug' => [
-            'className' => 'Cake\Log\Engine\FileLog',
+            'className' => FileLog::class,
             'path' => env('LOG_DIR', LOGS),
             'file' => 'gotea-access',
             'url' => env('LOG_DEBUG_URL', null),
@@ -319,7 +327,7 @@ return [
             'levels' => ['notice', 'info', 'debug'],
         ],
         'error' => [
-            'className' => 'Cake\Log\Engine\FileLog',
+            'className' => FileLog::class,
             'path' => env('LOG_DIR', LOGS),
             'file' => 'gotea-error',
             'url' => env('LOG_ERROR_URL', null),
@@ -328,7 +336,7 @@ return [
         ],
         // To enable this dedicated query log, you need set your datasource's log flag to true
         'queries' => [
-            'className' => 'Cake\Log\Engine\FileLog',
+            'className' => FileLog::class,
             'path' => env('LOG_DIR', LOGS),
             'file' => 'gotea-query',
             'url' => env('LOG_QUERIES_URL', null),

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -19,6 +19,10 @@ use Cake\Core\Configure;
  * be put here.
  */
 
+// Set the fullBaseUrl to allow URLs to be generated in shell tasks.
+// This is useful when sending email from shells.
+//Configure::write('App.fullBaseUrl', php_uname('n'));
+
 // Set logs to different files so they don't have permission conflicts.
 Configure::write('Log.debug.file', 'gotea-cli-debug');
 Configure::write('Log.error.file', 'gotea-cli-error');

--- a/config/requirements.php
+++ b/config/requirements.php
@@ -13,7 +13,7 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
- /*
+/*
  * You can empty out this file, if you are certain that you match all requirements.
  */
 
@@ -21,7 +21,7 @@
  * You can remove this if you are confident that your PHP version is sufficient.
  */
 if (version_compare(PHP_VERSION, '7.1.3') < 0) {
-    trigger_error('Your PHP version must be equal or higher than 7.0.0 to use CakePHP.' . PHP_EOL, E_USER_ERROR);
+    trigger_error('Your PHP version must be equal or higher than 7.1.3 to use CakePHP.' . PHP_EOL, E_USER_ERROR);
 }
 
 /*

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,20 +1,33 @@
 <?php
-
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Gotea;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
-use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Routing\Middleware\AssetMiddleware;
 use Cake\Routing\Middleware\RoutingMiddleware;
+use Gotoeveryone\Middleware\TraceMiddleware;
+use Gotoeveryone\Middleware\TransactionMiddleware;
 
 /**
- * アプリケーションクラス
+ * Application setup class.
  *
- * @author  Kazuki Kamizuru
- * @since   2017/06/07
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
  */
 class Application extends BaseApplication
 {
@@ -25,9 +38,11 @@ class Application extends BaseApplication
     {
         // Call parent to load bootstrap from files.
         parent::bootstrap();
+
         if (PHP_SAPI === 'cli') {
             $this->bootstrapCli();
         }
+
         /*
          * Only try to load DebugKit in development mode
          * Debug Kit should not be installed on a production system
@@ -35,11 +50,15 @@ class Application extends BaseApplication
         if (Configure::read('debug')) {
             $this->addPlugin(\DebugKit\Plugin::class);
         }
+
         // Load more plugins here
     }
 
     /**
-     * {@inheritDoc}
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
      */
     public function middleware($middlewareQueue)
     {
@@ -47,13 +66,25 @@ class Application extends BaseApplication
             // Catch any exceptions in the lower layers,
             // and make an error page/response
             ->add(new ErrorHandlerMiddleware(null, Configure::read('Error')))
+
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(new AssetMiddleware([
                 'cacheTime' => Configure::read('Asset.cacheTime')
             ]))
+
             // Add routing middleware.
+            // If you have a large number of routes connected, turning on routes
+            // caching in production could improve performance. For that when
+            // creating the middleware instance specify the cache config name by
+            // using it's second constructor argument:
+            // `new RoutingMiddleware($this, '_cake_routes_')`
             ->add(new RoutingMiddleware($this, '_cake_routes_'))
-            ->add(new CsrfProtectionMiddleware());
+
+            // Add trace middleware.
+            ->add(new TraceMiddleware())
+
+            // Add transaction middleware.
+            ->add(new TransactionMiddleware());
 
         return $middlewareQueue;
     }
@@ -68,7 +99,9 @@ class Application extends BaseApplication
         } catch (MissingPluginException $e) {
             // Do not halt if the plugin is missing
         }
+
         $this->addPlugin('Migrations');
+
         // Load more plugins here
     }
 }


### PR DESCRIPTION
### 概要

- cakephp 3.8 を利用するよう修正
- cakephp/app の 3.8.0 ブランチにある記述に合わせて修正

### 対応内容

- 
