### PR TITLE
fixes #764 表示項目不備修正

### DIFF
--- a/src/Template/Element/TitleScores/list.ctp
+++ b/src/Template/Element/TitleScores/list.ctp
@@ -50,8 +50,8 @@
             </span>
             <span class="table-column table-column_name">
                 <?php if (!empty($player)) : ?>
-                <span <?= $titleScore->isSelected($titleScore->winner, $player->id) ? 'class="selected"' : '' ?>>
-                    <?= h($titleScore->winner_name) ?>
+                <span <?= $titleScore->isSelected($titleScore->loser, $player->id) ? 'class="selected"' : '' ?>>
+                    <?= h($titleScore->loser_name) ?>
                 </span>
                 <?php else: ?>
                     <?php if (!empty($titleScore->loser)) : ?>


### PR DESCRIPTION
### 対応内容

- 棋士単位の成績表示時に敗者の表示が正しくなかったため修正
