### PR TITLE
merges #767

### DIFF
--- a/config/Migrations/20200124095430_AddIsOfficialToTitles.php
+++ b/config/Migrations/20200124095430_AddIsOfficialToTitles.php
@@ -1,0 +1,25 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddIsOfficialToTitles extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('titles')
+            ->addColumn('is_official', 'boolean', [
+                'comment' => '公式戦フラグ',
+                'default' => true,
+                'limit' => null,
+                'null' => false,
+                'after' => 'is_output',
+            ])
+            ->update();
+    }
+}

--- a/config/Migrations/20200124095434_AddIsOfficialToRetentionHistories.php
+++ b/config/Migrations/20200124095434_AddIsOfficialToRetentionHistories.php
@@ -1,0 +1,25 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddIsOfficialToRetentionHistories extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('retention_histories')
+            ->addColumn('is_official', 'boolean', [
+                'comment' => '公式戦フラグ',
+                'default' => true,
+                'limit' => null,
+                'null' => false,
+                'after' => 'acquired',
+            ])
+            ->update();
+    }
+}

--- a/resources/assets/scripts/components/titles/AddHistory.vue
+++ b/resources/assets/scripts/components/titles/AddHistory.vue
@@ -12,7 +12,7 @@
           name="id"
         >
         <input
-          :value="isTeamHidden"
+          :value="isTeamHidden ? 1 : 0"
           type="hidden"
           name="is_team"
         >
@@ -54,7 +54,26 @@
           >
         </div>
       </div>
-      <div class="detail_box_item box-2" />
+      <div class="detail_box_item box-1">
+        <div class="input checkbox">
+          <input
+            name="is_official"
+            value="0"
+            type="hidden"
+          >
+          <label class="checkbox-label" for="official">
+            <input
+              id="official"
+              v-model="isOfficial"
+              type="checkbox"
+              class="official"
+              name="is_official"
+            >
+            <span>公式戦</span>
+          </label>
+        </div>
+      </div>
+      <div class="detail_box_item box-1" />
       <div class="detail_box_item detail_box_item-buttons box-3">
         <div class="input checkbox">
           <input
@@ -245,6 +264,7 @@ export default Vue.extend({
       year: '' as number | string,
       holding: '' as number | string,
       acquired: '',
+      isOfficial: true,
       name: '',
       playerId: null as number | null,
       countryId: null as number | null,
@@ -278,6 +298,7 @@ export default Vue.extend({
           this.countryId = json.countryId;
           this.year = json.targetYear;
           this.acquired = json.acquired;
+          this.isOfficial = json.isOfficial;
           this.viewName = json.winPlayerName;
           this.teamName = json.winGroupName;
           this.edit = true;
@@ -361,6 +382,7 @@ export default Vue.extend({
       this.year = '';
       this.holding = '';
       this.acquired = '';
+      this.isOfficial = true;
       this.name = '';
       this.playerId = null;
       this.countryId = null;

--- a/resources/assets/scripts/components/titles/Index.vue
+++ b/resources/assets/scripts/components/titles/Index.vue
@@ -14,6 +14,7 @@
           <span class="table-column table-column_modified">修正日</span>
           <span class="table-column table-column_closed">終了<br>棋戦</span>
           <span class="table-column table-column_output">出力</span>
+          <span class="table-column table-column_official">公式戦</span>
           <span class="table-column table-column_open-detail">詳細</span>
         </li>
       </ul>
@@ -70,6 +71,8 @@ export default Vue.extend({
         htmlFileModified: '',
         url: null,
         isClosed: false,
+        isOutput: true,
+        isOfficial: true,
       });
     },
     outputJson() {

--- a/resources/assets/scripts/components/titles/Item.vue
+++ b/resources/assets/scripts/components/titles/Item.vue
@@ -33,6 +33,9 @@
     <span class="table-column table-column_output">
       <input @change="save" v-model="item.isOutput" type="checkbox">
     </span>
+    <span class="table-column table-column_official">
+      <input @change="save" v-model="item.isOfficial" type="checkbox">
+    </span>
     <span class="table-column table-column_open-detail">
       <a @click="select()" v-text="label" class="view-link" />
     </span>

--- a/resources/assets/scripts/types/titles.ts
+++ b/resources/assets/scripts/types/titles.ts
@@ -14,6 +14,8 @@ export interface TitleResultItem {
   htmlFileModified: string;
   url: string | null;
   isClosed: boolean;
+  isOutput: boolean;
+  isOfficial: boolean;
 }
 
 export interface Player {

--- a/resources/assets/styles/modules/_titles.scss
+++ b/resources/assets/styles/modules/_titles.scss
@@ -10,11 +10,11 @@
 
   .table-column {
     &_name {
-      width: 17%;
+      width: 15%;
     }
 
     &_winner {
-      width: 15%;
+      width: 14%;
     }
 
     &_holding,
@@ -29,7 +29,8 @@
 
     &_team,
     &_closed,
-    &_output {
+    &_output,
+    &_official {
       width: 5%;
       text-align: center;
     }

--- a/src/Collection/Iterator/TitlesIterator.php
+++ b/src/Collection/Iterator/TitlesIterator.php
@@ -36,6 +36,7 @@ class TitlesIterator
             'isRecent' => $item->isRecentModified(),
             'isClosed' => $item->is_closed,
             'isOutput' => $item->is_output,
+            'isOfficial' => $item->is_official,
             'url' => Router::url(['_name' => 'view_title', $item->id]),
         ];
     }

--- a/src/Controller/Api/RetentionHistoriesController.php
+++ b/src/Controller/Api/RetentionHistoriesController.php
@@ -31,6 +31,7 @@ class RetentionHistoriesController extends ApiController
             'winGroupName' => $history->win_group_name,
             'isTeam' => $history->is_team,
             'acquired' => $history->acquired->format('Y/m/d'),
+            'isOfficial' => $history->is_official,
             'playerId' => $history->player_id,
             'countryId' => $history->country_id,
         ]);

--- a/src/Model/Entity/RetentionHistory.php
+++ b/src/Model/Entity/RetentionHistory.php
@@ -14,6 +14,7 @@ namespace Gotea\Model\Entity;
  * @property string $win_group_name
  * @property bool $is_team
  * @property \Cake\I18n\FrozenDate $acquired
+ * @property bool $is_official
  * @property \Cake\I18n\FrozenTime $created
  * @property \Cake\I18n\FrozenTime $modified
  *

--- a/src/Model/Entity/Title.php
+++ b/src/Model/Entity/Title.php
@@ -19,6 +19,7 @@ use Cake\I18n\FrozenDate;
  * @property bool $is_team
  * @property bool $is_closed
  * @property bool $is_output
+ * @property bool $is_official
  * @property \Cake\I18n\FrozenTime $created
  * @property string $created_by
  * @property \Cake\I18n\FrozenTime $modified
@@ -153,6 +154,7 @@ class Title extends AppEntity
             'htmlFileModified' => $this->html_file_modified->format('Y/m/d'),
             'isClosed' => $this->is_closed,
             'isOutput' => $this->is_output,
+            'isOfficial' => $this->is_official,
         ];
     }
 }

--- a/src/Model/Table/RetentionHistoriesTable.php
+++ b/src/Model/Table/RetentionHistoriesTable.php
@@ -40,23 +40,66 @@ class RetentionHistoriesTable extends AppTable
     {
         $validator
             ->integer('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
-        return $validator
-            ->requirePresence([
-                'title_id', 'holding', 'target_year', 'name', 'acquired',
-            ])
+        $validator
+            ->integer('title_id')
+            ->requirePresence('title_id', 'create')
+            ->notEmptyString('title_id');
+
+        $validator
             ->integer('player_id')
-            ->integer('holding')
-            ->integer('target_year')
-            ->requirePresence(['player_id'], function ($context) {
+            ->requirePresence('player_id', function ($context) {
                 return empty($context['data']['is_team']);
             })
+            ->notEmptyString('player_id', null, function ($context) {
+                return empty($context['data']['is_team']);
+            });
+
+        $validator
+            ->integer('country_id')
+            ->allowEmptyString('country_id');
+
+        $validator
+            ->integer('holding')
+            ->requirePresence('holding', 'create')
+            ->notEmptyString('holding');
+
+        $validator
+            ->integer('target_year')
+            ->requirePresence('target_year', 'create')
+            ->notEmptyString('target_year');
+
+        $validator
+            ->scalar('name')
+            ->maxLength('name', 30)
+            ->requirePresence('name', 'create')
+            ->notEmptyString('name');
+
+        $validator
+            ->scalar('win_group_name')
+            ->maxLength('win_group_name', 30)
             ->requirePresence('win_group_name', function ($context) {
                 return !empty($context['data']['is_team']);
             })
-            ->maxLength('win_group_name', 30)
-            ->date('acquired', 'y/m/d');
+            ->notEmptyString('win_group_name', null, function ($context) {
+                return !empty($context['data']['is_team']);
+            });
+
+        $validator
+            ->boolean('is_team')
+            ->notEmptyString('is_team');
+
+        $validator
+            ->date('acquired', ['y/m/d'])
+            ->requirePresence('acquired', 'create')
+            ->notEmptyDate('acquired');
+
+        $validator
+            ->boolean('is_official')
+            ->notEmptyString('is_official');
+
+        return $validator;
     }
 
     /**

--- a/src/Model/Table/TitlesTable.php
+++ b/src/Model/Table/TitlesTable.php
@@ -3,6 +3,7 @@
 namespace Gotea\Model\Table;
 
 use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
@@ -37,27 +38,86 @@ class TitlesTable extends AppTable
      */
     public function validationDefault(Validator $validator)
     {
-        return $validator
-            ->requirePresence([
-                'country_id', 'name', 'name_english', 'holding',
-                'sort_order', 'html_file_name', 'html_file_modified',
-            ], 'create')
-            ->notEmpty([
-                'name', 'name_english', 'holding',
-                'html_file_name', 'html_file_modified',
-            ])
-            ->integer('holding')
-            ->integer('sort_order')
+        $validator
+            ->integer('id')
+            ->allowEmptyString('id', null, 'create');
+
+        $validator
+            ->integer('country_id')
+            ->requirePresence('country_id', 'create')
+            ->notEmptyString('country_id');
+
+        $validator
+            ->scalar('name')
+            ->maxLength('name', 30)
+            ->requirePresence('name', 'create')
+            ->notEmptyString('name');
+
+        $validator
+            ->scalar('name_english')
             ->alphaNumeric('name_english')
+            ->maxLength('name_english', 60)
+            ->requirePresence('name_english', 'create')
+            ->notEmptyString('name_english');
+
+        $validator
+            ->integer('holding')
+            ->requirePresence('holding', 'create')
+            ->notEmptyString('holding');
+
+        $validator
+            ->integer('sort_order')
+            ->requirePresence('sort_order', 'create')
+            ->notEmptyString('sort_order');
+
+        $validator
+            ->scalar('html_file_name')
+            ->maxLength('html_file_name', 30)
+            ->requirePresence('html_file_name', 'create')
+            ->notEmptyString('html_file_name')
             ->add('html_file_name', 'custom', [
                 'rule' => function ($value) {
                     return (bool)preg_match('/^[a-zA-Z0-9\(\)\'\-\/\s]+$/', $value);
                 },
-            ])
-            ->maxLength('name', 30)
-            ->maxLength('name_english', 60)
-            ->maxLength('html_file_name', 30)
-            ->date('html_file_modified', 'y/m/d');
+            ]);
+
+        $validator
+            ->date('html_file_modified', ['y/m/d'])
+            ->requirePresence('html_file_modified', 'create')
+            ->notEmptyDate('html_file_modified');
+
+        $validator
+            ->scalar('remarks')
+            ->maxLength('remarks', 500)
+            ->allowEmptyString('remarks');
+
+        $validator
+            ->boolean('is_team')
+            ->notEmptyString('is_team');
+
+        $validator
+            ->boolean('is_closed')
+            ->notEmptyString('is_closed');
+
+        $validator
+            ->boolean('is_output')
+            ->notEmptyString('is_output');
+
+        $validator
+            ->boolean('is_official')
+            ->notEmptyString('is_official');
+
+        return $validator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->add($rules->existsIn(['country_id'], 'Countries'));
+
+        return $rules;
     }
 
     /**

--- a/src/Template/Element/Titles/base.ctp
+++ b/src/Template/Element/Titles/base.ctp
@@ -9,7 +9,7 @@
     <?= $this->Form->control('id') ?>
     <div class="page-header">タイトル情報 (ID: <?= h($title->id) ?>)</div>
     <ul class="detail_box">
-        <li class="detail_box_item box-4">
+        <li class="detail_box_item box-3">
             <?php
             echo $this->Form->control('name', [
                 'label' => ['class' => 'label-row', 'text' => __d('model', 'name')],
@@ -62,6 +62,17 @@
                 <?php
                 echo $this->Form->label('is_output', __d('model', 'is_output'), ['class' => 'label-row']);
                 echo $this->Form->control('is_output', [
+                    'label' => false,
+                    'class' => 'input-row',
+                ]);
+                ?>
+            </div>
+        </li>
+        <li class="detail_box_item box-1">
+            <div class="input">
+                <?php
+                echo $this->Form->label('is_official', __d('model', 'is_official'), ['class' => 'label-row']);
+                echo $this->Form->control('is_official', [
                     'label' => false,
                     'class' => 'input-row',
                 ]);

--- a/tests/Fixture/RetentionHistoriesFixture.php
+++ b/tests/Fixture/RetentionHistoriesFixture.php
@@ -27,6 +27,7 @@ class RetentionHistoriesFixture extends TestFixture
         'win_group_name' => ['type' => 'string', 'length' => 30, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '優勝チーム名', 'precision' => null, 'fixed' => null],
         'is_team' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '団体戦判定', 'precision' => null],
         'acquired' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '取得日', 'precision' => null],
+        'is_official' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '公式戦フラグ', 'precision' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
         'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
         'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],

--- a/tests/Fixture/TitlesFixture.php
+++ b/tests/Fixture/TitlesFixture.php
@@ -30,6 +30,7 @@ class TitlesFixture extends TestFixture
         'is_team' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '団体戦判定', 'precision' => null],
         'is_closed' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '終了済', 'precision' => null],
         'is_output' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => 'Go News 出力有無', 'precision' => null],
+        'is_official' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '公式戦フラグ', 'precision' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
         'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
         'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],

--- a/tests/TestCase/Model/Table/RetentionHistoriesTableTest.php
+++ b/tests/TestCase/Model/Table/RetentionHistoriesTableTest.php
@@ -110,8 +110,25 @@ class RetentionHistoriesTableTest extends TestCase
             $this->assertNotEmpty($result->getErrors());
         }
 
+        // notEmpty
+        $names = [
+            'title_id',
+            'holding',
+            'target_year',
+            'name',
+            'is_team',
+            'acquired',
+            'is_official',
+        ];
+        foreach ($params as $name => $value) {
+            $data = $params;
+            unset($data[$name]);
+            $result = $this->RetentionHistories->newEntity($data);
+            $this->assertNotEmpty($result->getErrors());
+        }
+
         // integer
-        $names = ['player_id', 'holding', 'target_year'];
+        $names = ['title_id', 'player_id', 'country_id', 'holding', 'target_year'];
         foreach ($names as $name) {
             $data = $params;
             $data[$name] = '1a';
@@ -127,19 +144,40 @@ class RetentionHistoriesTableTest extends TestCase
             $this->assertNotEmpty($result->getErrors());
         }
 
-        // notEmpty
-        // player_id
-        $data = $params;
-        $data['player_id'] = '';
-        $result = $this->RetentionHistories->newEntity($data);
-        $this->assertNotEmpty($result->getErrors());
+        // date
+        $names = ['acquired'];
+        foreach ($names as $name) {
+            $data = $params;
+            $data[$name] = '20180101';
+            $result = $this->RetentionHistories->newEntity($data);
+            $this->assertNotEmpty($result->getErrors());
 
-        // win_group_name
-        $data = $params;
-        $data['is_team'] = '1';
-        $data['win_group_name'] = '';
-        $result = $this->RetentionHistories->newEntity($data);
-        $this->assertNotEmpty($result->getErrors());
+            $data[$name] = 'testtest';
+            $result = $this->RetentionHistories->newEntity($data);
+            $this->assertNotEmpty($result->getErrors());
+        }
+
+        // boolean
+        $names = ['is_team', 'is_official'];
+        foreach ($names as $name) {
+            $data = $params;
+            $data[$name] = '0.5';
+            $result = $this->RetentionHistories->newEntity($data);
+            $this->assertNotEmpty($result->getErrors());
+
+            $data[$name] = 'test';
+            $result = $this->RetentionHistories->newEntity($data);
+            $this->assertNotEmpty($result->getErrors());
+        }
+
+        // allowEmptyString
+        $names = ['country_id'];
+        foreach ($names as $name) {
+            $data = $params;
+            $data[$name] = '';
+            $result = $this->RetentionHistories->newEntity($data);
+            $this->assertEmpty($result->getErrors());
+        }
 
         // id
         $data = $params;
@@ -148,12 +186,31 @@ class RetentionHistoriesTableTest extends TestCase
         $result = $this->RetentionHistories->patchEntity($exist, $data);
         $this->assertNotEmpty($result->getErrors());
 
-        // date
-        // acquired
+        // custom
         $data = $params;
-        $data['acquired'] = '20180101';
+        $data['is_team'] = '1';
+        $data['player_id'] = '1';
+        $data['win_group_name'] = '';
         $result = $this->RetentionHistories->newEntity($data);
         $this->assertNotEmpty($result->getErrors());
+
+        $data['is_team'] = '0';
+        $data['player_id'] = '';
+        $data['win_group_name'] = 'test';
+        $result = $this->RetentionHistories->newEntity($data);
+        $this->assertNotEmpty($result->getErrors());
+
+        $data['is_team'] = '1';
+        $data['player_id'] = '';
+        $data['win_group_name'] = 'test';
+        $result = $this->RetentionHistories->newEntity($data);
+        $this->assertEmpty($result->getErrors());
+
+        $data['is_team'] = '0';
+        $data['player_id'] = '1';
+        $data['win_group_name'] = '';
+        $result = $this->RetentionHistories->newEntity($data);
+        $this->assertEmpty($result->getErrors());
     }
 
     /**


### PR DESCRIPTION
### 概要

- タイトル・保持履歴に公式戦フラグを追加

### 対応内容

- `titles.is_official` を追加
- `retention_histories.is_official` を追加
- 上記フラグを制御できるよう画面を修正
- テストコード修正