### PR TITLE
merges #767

### DIFF
--- a/src/Template/Element/Players/retention_histories.ctp
+++ b/src/Template/Element/Players/retention_histories.ctp
@@ -8,12 +8,19 @@
     <div class="page-header">タイトル取得履歴<?= !$player->isNew() ? ' (ID: '. h($player->id) . ')' : '' ?></div>
     <?php $histories = $player->groupByYearFromHistories(); ?>
     <?php foreach ($histories as $key => $items) : ?>
-        <div class="label-row"><?= __('{0}年度', $key) ?></div>
+        <?php $unOfficialCount = count(array_filter($items, function ($item) {
+            return !$item->is_official;
+        })); ?>
+        <?php $titleCount = count($items) . ($unOfficialCount > 0 ? " (非公式{$unOfficialCount})" : '') ?>
+        <div class="label-row"><?= __('{0}年度: {1}', $key, $titleCount) ?></div>
         <?php foreach ($items as $item) : ?>
             <div class="input-row">
                 <span class="inner-column"><?= __('{0}期', $item->holding) ?></span>
                 <span class="inner-column"><?= h($item->name) ?></span>
                 <span class="inner-column"><?= h($item->title->country->label) ?></span>
+                <?php if (!$item->is_official) : ?>
+                    <span class="inner-column">（非公式戦）</span>
+                <?php endif ?>
             </div>
         <?php endforeach ?>
     <?php endforeach ?>

--- a/src/Template/Element/Titles/retention_histories.ctp
+++ b/src/Template/Element/Titles/retention_histories.ctp
@@ -28,6 +28,9 @@
                         <?php if ($title->country->isWorlds() && !$retention->is_team) : ?>
                         <span class="inner-column"><span>出場国：</span><?= h($retention->country->name) ?></span>
                         <?php endif ?>
+                        <?php if (!$retention->is_official) : ?>
+                            <span class="inner-column">（非公式戦）</span>
+                        <?php endif ?>
                         <?php if ($retention->isRecent()) : ?>
                             <span class="inner-column"><span class="mark-new">NEW!</span></span>
                         <?php endif ?>
@@ -48,6 +51,9 @@
                         <span class="inner-column"><span>優勝者：</span><?= h($history->winner_name) ?></span>
                         <?php if ($title->country->isWorlds() && !$history->is_team) : ?>
                         <span class="inner-column"><span>出場国：</span><?= h($history->country->name) ?></span>
+                        <?php endif ?>
+                        <?php if (!$history->is_official) : ?>
+                            <span class="inner-column">（非公式戦）</span>
                         <?php endif ?>
                     </div>
                     <div class="detail_box_item detail_box_item-buttons box-2">


### PR DESCRIPTION
### 概要

- 非公式のラベルを表示

### 対応内容

- 棋士詳細の保持履歴タブに年度単位のタイトル数（総数・非公式棋戦のみ）と非公式戦のラベルを追加
- タイトル詳細の保持履歴タブに非公式戦のラベルを追加