### PR TITLE
merges #836

### DIFF
--- a/resources/assets/scripts/components/ranking/Header.vue
+++ b/resources/assets/scripts/components/ranking/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="search-header">
     <li class="search-row">
-      <fieldset class="search-box">
+      <div class="search-box">
         <label class="search-box_label ranking_label">抽出対象</label>
         <select
           v-model="select.year"
@@ -37,10 +37,10 @@
             v-text="limit.text"
           />
         </select>
-      </fieldset>
+      </div>
     </li>
     <li class="search-row">
-      <fieldset class="search-box">
+      <div class="search-box">
         <label class="search-box_label ranking_label">対局日</label>
         <input
           v-model="select.from"
@@ -59,21 +59,21 @@
           name="to"
           class="ranking_date datepicker"
         >
-      </fieldset>
+      </div>
     </li>
     <li class="search-row">
-      <fieldset class="search-box">
+      <div class="search-box">
         <label class="search-box_label ranking_label">最終更新日</label>
         <span v-text="lastUpdate" class="lastUpdate" />
-      </fieldset>
-      <fieldset class="search-box search-box-right">
+      </div>
+      <div class="search-box search-box-right">
         <button @click="clearDate()" type="button">
           日付をクリア
         </button>
         <button @click="json()" type="button" class="button button-primary">
           JSON出力
         </button>
-      </fieldset>
+      </div>
     </li>
   </ul>
 </template>

--- a/resources/assets/scripts/components/ranks/Header.vue
+++ b/resources/assets/scripts/components/ranks/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="search-header">
     <li class="search-row">
-      <fieldset class="search-box">
+      <div class="search-box">
         <label class="search-box_label">対象国</label>
         <select v-model="select.country" @change="changeValue($event)" class="country">
           <option
@@ -11,7 +11,7 @@
             v-text="country.text"
           />
         </select>
-      </fieldset>
+      </div>
     </li>
   </ul>
 </template>

--- a/resources/assets/scripts/components/titles/Header.vue
+++ b/resources/assets/scripts/components/titles/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="search-header">
     <li class="search-row">
-      <fieldset class="search-box">
+      <div class="search-box">
         <label class="search-box_label">対象国</label>
         <select
           @change="changeValue($event)"
@@ -15,8 +15,8 @@
             v-text="country.text"
           />
         </select>
-      </fieldset>
-      <fieldset class="search-box">
+      </div>
+      <div class="search-box">
         <label class="search-box_label">非出力対象</label>
         <select
           @change="changeValue($event)"
@@ -30,8 +30,8 @@
             v-text="option.text"
           />
         </select>
-      </fieldset>
-      <fieldset class="search-box">
+      </div>
+      <div class="search-box">
         <label class="search-box_label">終了棋戦</label>
         <select
           @change="changeValue($event)"
@@ -45,8 +45,8 @@
             v-text="option.text"
           />
         </select>
-      </fieldset>
-      <fieldset class="search-box search-box-right">
+      </div>
+      <div class="search-box search-box-right">
         <button
           @click="add()"
           class="button button-secondary"
@@ -61,7 +61,7 @@
         >
           JSON出力
         </button>
-      </fieldset>
+      </div>
     </li>
   </ul>
 </template>

--- a/resources/assets/styles/base/_normalize.scss
+++ b/resources/assets/styles/base/_normalize.scss
@@ -123,6 +123,8 @@ input[type='checkbox'] {
   margin: 0;
   min-width: 18px;
   min-height: 18px;
+  width: 18px;
+  height: 18px;
 }
 
 button {

--- a/resources/assets/styles/partials/_search.scss
+++ b/resources/assets/styles/partials/_search.scss
@@ -137,6 +137,7 @@
     }
   }
 
+  margin-bottom: 10px;
   border: 1px solid $c_black;
 }
 

--- a/resources/assets/styles/view.scss
+++ b/resources/assets/styles/view.scss
@@ -21,6 +21,10 @@
     input[type='checkbox'] {
       width: auto;
     }
+
+    .text {
+      margin-left: 0.3rem;
+    }
   }
 
   .page-header {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -23,6 +23,7 @@ class FormHelper extends BaseFormHelper
         parent::__construct($View, $config);
 
         $this->setTemplates([
+            'nestingLabel' => '{{hidden}}<label{{attrs}}>{{input}}<span class="text">{{text}}</span></label>',
             'date' => '{{year}}{{month}}{{day}}',
             'datetime' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}',
             // エラーメッセージは個別に出力しない

--- a/templates/Notifications/index.php
+++ b/templates/Notifications/index.php
@@ -7,13 +7,13 @@
 <div class="notifications index large-9 medium-8 columns content">
     <ul class="search-header">
         <li class="search-row">
-            <fieldset class="search-box search-box-right">
+            <div class="search-box search-box-right">
                 <?= $this->Html->link(__('新規登録'), [
                     '_name' => 'new_notification',
                 ], [
                     'class' => 'layout-button button-secondary',
                 ]) ?>
-            </fieldset>
+            </div>
         </li>
     </ul>
     <?php if (!empty($notifications)) : ?>

--- a/templates/Players/index.php
+++ b/templates/Players/index.php
@@ -2,30 +2,30 @@
     <?= $this->Form->create($form, ['class' => 'main-form', 'type' => 'get', 'url' => ['_name' => 'find_players']]) ?>
     <ul class="search-header">
         <li class="search-row">
-            <fieldset class="search-box">
+            <div class="search-box">
                 <?= $this->Form->control('name', [
                     'label' => ['text' => __d('model', 'name')],
                     'class' => 'name',
                     'value' => $this->getRequest()->getQuery('name'),
                 ]) ?>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <?= $this->Form->control('name_english', [
                     'label' => ['text' => __d('model', 'name_english')],
                     'class' => 'name',
                     'value' => $this->getRequest()->getQuery('name_english'),
                 ]) ?>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <?= $this->Form->control('name_other', [
                     'label' => ['text' => __d('model', 'name_other')],
                     'class' => 'name',
                     'value' => $this->getRequest()->getQuery('name_other'),
                 ]) ?>
-            </fieldset>
+            </div>
         </li>
         <li class="search-row">
-            <fieldset class="search-box">
+            <div class="search-box">
                 <?= $this->cell('Countries', [
                     'hasTitleOnly' => true,
                     [
@@ -36,18 +36,18 @@
                         '@change' => 'changeCountry($event)',
                     ],
                 ])->render() ?>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <?= $this->cell('Organizations', [
                     [
                         'label' => ['text' => __d('model', 'organization_id')],
                         'class' => 'organization',
                         'empty' => true,
                         'value' => $this->getRequest()->getQuery('organization_id'),
-                    ]
+                    ],
                 ])->render() ?>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <?= $this->Form->control('rank_id', [
                     'label' => ['text' => __d('model', 'rank_id')],
                     'options' => $ranks,
@@ -55,16 +55,16 @@
                     'empty' => true,
                     'value' => $this->getRequest()->getQuery('rank_id'),
                 ]) ?>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <?= $this->Form->sexes([
                     'label' => ['text' => __d('model', 'sex')],
                     'class' => 'sex',
                     'empty' => true,
                     'value' => $this->getRequest()->getQuery('sex'),
                 ]) ?>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <div>
                     <?php
                     echo $this->Form->label('joined_from', '入段年', ['class' => 'search-box_label']);
@@ -83,18 +83,18 @@
                     ]);
                     ?>
                 </div>
-            </fieldset>
-            <fieldset class="search-box">
+            </div>
+            <div class="search-box">
                 <?= $this->Form->filters('is_retired', [
                     'label' => ['text' => '引退者'],
                     'class' => 'excluded',
                     'value' => $this->getRequest()->getQuery('is_retired'),
                 ]) ?>
-            </fieldset>
-            <fieldset class="search-box search-box-right">
+            </div>
+            <div class="search-box search-box-right">
                 <add-button :country-id="countryId" :changed="changed" :url="'<?= $this->Url->build(['_name' => 'new_player']) ?>'" :param-id="'<?= $this->getRequest()->getData('country_id') ?>'"></add-button>
                 <?= $this->Form->button('検索', ['type' => 'submit', 'class' => 'button button-primary']) ?>
-            </fieldset>
+            </div>
         </li>
     </ul>
 

--- a/templates/TitleScores/index.php
+++ b/templates/TitleScores/index.php
@@ -9,23 +9,23 @@
         <?= $this->Form->create($form, ['class' => 'main-form', 'type' => 'get', 'url' => ['_name' => 'find_scores']]) ?>
         <ul class="search-header">
             <li class="search-row">
-                <fieldset class="search-box">
+                <div class="search-box">
                     <?= $this->Form->control('name', [
                         'label' => ['text' => '棋士名'],
                         'class' => 'name',
                         'value' => $this->getRequest()->getQuery('name'),
                     ]) ?>
-                </fieldset>
-                <fieldset class="search-box">
+                </div>
+                <div class="search-box">
                     <?= $this->Form->control('title_name', [
                         'label' => ['text' => 'タイトル名'],
                         'class' => 'title_name',
                         'value' => $this->getRequest()->getQuery('title_name'),
                     ]) ?>
-                </fieldset>
+                </div>
             </li>
             <li class="search-row">
-                <fieldset class="search-box">
+                <div class="search-box">
                     <?= $this->cell('Countries', [
                         'hasTitleOnly' => false,
                         [
@@ -33,16 +33,16 @@
                             'value' => $this->getRequest()->getQuery('country_id'),
                         ],
                     ]) ?>
-                </fieldset>
-                <fieldset class="search-box">
+                </div>
+                <div class="search-box">
                     <?= $this->Form->years('target_year', [
                         'label' => ['text' => '対局年'],
                         'class' => 'year',
                         'empty' => true,
                         'value' => $this->getRequest()->getQuery('target_year'),
                     ]) ?>
-                </fieldset>
-                <fieldset class="search-box">
+                </div>
+                <div class="search-box">
                     <?php
                     echo $this->Form->label('started', '対局日', ['class' => 'search-box_label']);
                     echo $this->Form->text('started', [
@@ -55,10 +55,10 @@
                         'value' => $this->getRequest()->getQuery('ended'),
                     ]);
                     ?>
-                </fieldset>
-                <fieldset class="search-box search-box-right">
+                </div>
+                <div class="search-box search-box-right">
                     <?= $this->Form->button('検索', ['type' => 'submit', 'class' => 'button button-primary']) ?>
-                </fieldset>
+                </div>
             </li>
         </ul>
         <?= $this->Form->end() ?>

--- a/templates/Users/index.php
+++ b/templates/Users/index.php
@@ -2,7 +2,7 @@
     'method' => 'post',
     'url' => ['_name' => 'login'],
 ]) ?>
-<fieldset class="login-row">
+<div class="login-row">
     <?=
         $this->Form->control('account', [
             'label' => [
@@ -12,8 +12,8 @@
             'class' => 'login-account',
         ]);
     ?>
-</fieldset>
-<fieldset class="login-row">
+</div>
+<div class="login-row">
     <?=
         $this->Form->control('password', [
             'label' => [
@@ -23,10 +23,10 @@
             'class' => 'login-password',
         ]);
     ?>
-</fieldset>
-<fieldset class="row button-row">
+</div>
+<div class="row button-row">
     <?= $this->Form->hidden('redirect', ['value' => $this->getRequest()->getQuery('redirect')]) ?>
     <?= $this->Form->button('ログイン', ['type' => 'submit', 'class' => 'button button-primary']) ?>
     <?= $this->Form->button('クリア', ['type' => 'reset']) ?>
-</fieldset>
+</div>
 <?= $this->Form->end() ?>


### PR DESCRIPTION
### 概要

- Chrome でのレイアウト崩れを修正

### 対応内容

- Chrome や Edge では `<fieldset>` タグに flexbox や grid が設定できないため、別のタグに変更
- 検索結果一覧下にマージンを設定
- チェックボックスのサイズ変更
- チェックボックス横のラベルに余白を追加
