### PR TITLE
merges #846

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,12 @@ module.exports = () => {
             test: /\.(sa|sc|c)ss$/,
             use: [
               'vue-style-loader',
-              'css-loader',
+              {
+                loader: 'css-loader',
+                options: {
+                  esModule: false,
+                },
+              },
               'sass-loader',
               {
                 loader: 'sass-resources-loader',
@@ -120,7 +125,16 @@ module.exports = () => {
         rules: [
           {
             test: /\.(sa|sc|c)ss$/,
-            use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+            use: [
+              MiniCssExtractPlugin.loader,
+              {
+                loader: 'css-loader',
+                options: {
+                  esModule: false,
+                },
+              },
+              'sass-loader',
+            ],
           },
         ],
       },


### PR DESCRIPTION
### 概要

- css-loader の設定を変更
  - css-loader 4.x から esModule が true になるが、これにより vue の sfc 内に記載した css が正しく読み込まれない事象が発生していた（[参考](https://github.com/vuejs/vue-style-loader/issues/46)）

### 対応内容

- options に `esModule: false` を追加
