### PR TITLE
merges #798 

### DIFF
--- a/config/Migrations/20210322044346_AddBroadcastedToRetentionHistories.php
+++ b/config/Migrations/20210322044346_AddBroadcastedToRetentionHistories.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class AddBroadcastedToRetentionHistories extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('retention_histories');
+        $table->addColumn('broadcasted', 'date', [
+            'comment' => '放映日',
+            'default' => null,
+            'limit' => null,
+            'null' => true,
+            'after' => 'is_official',
+        ]);
+        $table->update();
+    }
+}

--- a/resources/assets/scripts/components/titles/AddHistory.vue
+++ b/resources/assets/scripts/components/titles/AddHistory.vue
@@ -46,7 +46,7 @@
           <input
             id="acquired"
             v-model="acquired"
-            @change="saveDatepicker"
+            @change="onChangeAcquired"
             type="text"
             maxlength="4"
             class="acquired datepicker"
@@ -56,6 +56,21 @@
         </div>
       </div>
       <div class="detail_box_item box-2">
+        <div class="input number">
+          <label for="acquired">放映日</label>
+          <input
+            id="broadcasted"
+            v-model="broadcasted"
+            @change="onChangeBroadcasted"
+            type="text"
+            maxlength="4"
+            class="broadcasted datepicker"
+            autocomplete="off"
+            name="broadcasted"
+          >
+        </div>
+      </div>
+      <div class="detail_box_item detail_box_item-buttons box-4">
         <div class="input checkbox">
           <input
             name="is_official"
@@ -77,9 +92,6 @@
             <span>公式戦</span>
           </label>
         </div>
-      </div>
-      <div class="detail_box_item box-1" />
-      <div class="detail_box_item detail_box_item-buttons box-3">
         <div class="input checkbox">
           <input
             name="newest"
@@ -269,6 +281,7 @@ export default Vue.extend({
       year: '' as number | string,
       holding: '' as number | string,
       acquired: '',
+      broadcasted: '',
       isOfficial: true,
       name: '',
       playerId: null as number | null,
@@ -304,6 +317,7 @@ export default Vue.extend({
           this.year = json.targetYear;
           this.acquired = json.acquired;
           this.isOfficial = json.isOfficial;
+          this.broadcasted = json.broadcasted;
           this.viewName = json.winPlayerName;
           this.teamName = json.winGroupName;
           this.edit = true;
@@ -324,10 +338,16 @@ export default Vue.extend({
     getTeamHidden(value: boolean) {
       return value ? '1' : '';
     },
-    saveDatepicker($event: Event) {
+    onChangeAcquired($event: Event) {
       const target = $event.target as HTMLInputElement;
       if (this.acquired !== target.value) {
         this.acquired = target.value;
+      }
+    },
+    onChangeBroadcasted($event: Event) {
+      const target = $event.target as HTMLInputElement;
+      if (this.broadcasted !== target.value) {
+        this.broadcasted = target.value;
       }
     },
     search() {
@@ -388,6 +408,7 @@ export default Vue.extend({
       this.holding = '';
       this.acquired = '';
       this.isOfficial = true;
+      this.broadcasted = '';
       this.name = '';
       this.playerId = null;
       this.countryId = null;

--- a/src/Controller/Api/RetentionHistoriesController.php
+++ b/src/Controller/Api/RetentionHistoriesController.php
@@ -33,6 +33,7 @@ class RetentionHistoriesController extends ApiController
             'isTeam' => $history->is_team,
             'acquired' => $history->acquired->format('Y/m/d'),
             'isOfficial' => $history->is_official,
+            'broadcasted' => $history->broadcasted === null ? null : $history->broadcasted->format('Y/m/d'),
             'playerId' => $history->player_id,
             'countryId' => $history->country_id,
         ]);

--- a/src/Model/Entity/RetentionHistory.php
+++ b/src/Model/Entity/RetentionHistory.php
@@ -16,6 +16,7 @@ namespace Gotea\Model\Entity;
  * @property bool $is_team
  * @property \Cake\I18n\FrozenDate $acquired
  * @property bool $is_official
+ * @property \Cake\I18n\FrozenDate|null $broadcasted
  * @property \Cake\I18n\FrozenTime $created
  * @property \Cake\I18n\FrozenTime $modified
  *
@@ -66,6 +67,11 @@ class RetentionHistory extends AppEntity
      */
     public function isRecent(): bool
     {
+        // 放映日があればその値を基準に判定する
+        if ($this->broadcasted !== null) {
+            return $this->broadcasted->wasWithinLast('20 days');
+        }
+
         return $this->acquired->wasWithinLast('20 days');
     }
 }

--- a/src/Model/Table/RetentionHistoriesTable.php
+++ b/src/Model/Table/RetentionHistoriesTable.php
@@ -102,7 +102,6 @@ class RetentionHistoriesTable extends AppTable
 
         $validator
             ->date('broadcasted', ['y/m/d'])
-            ->requirePresence('broadcasted', 'create')
             ->allowEmptyDate('broadcasted');
 
         return $validator;

--- a/src/Model/Table/RetentionHistoriesTable.php
+++ b/src/Model/Table/RetentionHistoriesTable.php
@@ -100,6 +100,11 @@ class RetentionHistoriesTable extends AppTable
             ->boolean('is_official')
             ->notEmptyString('is_official');
 
+        $validator
+            ->date('broadcasted', ['y/m/d'])
+            ->requirePresence('broadcasted', 'create')
+            ->allowEmptyDate('broadcasted');
+
         return $validator;
     }
 

--- a/tests/Fixture/RetentionHistoriesFixture.php
+++ b/tests/Fixture/RetentionHistoriesFixture.php
@@ -26,6 +26,7 @@ class RetentionHistoriesFixture extends TestFixture
         'is_team' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '団体戦判定', 'precision' => null],
         'acquired' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '取得日', 'precision' => null],
         'is_official' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '公式戦フラグ', 'precision' => null],
+        'broadcasted' => ['type' => 'date', 'length' => null, 'null' => true, 'default' => null, 'comment' => '放映日', 'precision' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
         'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
         'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],

--- a/tests/TestCase/Model/Entity/RetentionHistoryTest.php
+++ b/tests/TestCase/Model/Entity/RetentionHistoryTest.php
@@ -43,11 +43,28 @@ class RetentionHistoryTest extends TestCase
     }
 
     /**
-     * Test isRecent method
+     * Test isRecent method if `broadcasted` field has value
      *
      * @return void
      */
-    public function testIsRecent()
+    public function testIsRecentHasBroadcasted()
+    {
+        $this->RetentionHistory->broadcasted = FrozenDate::now();
+        $this->assertTrue($this->RetentionHistory->isRecent());
+
+        $this->RetentionHistory->broadcasted = FrozenDate::now()->subDay(20);
+        $this->assertTrue($this->RetentionHistory->isRecent());
+
+        $this->RetentionHistory->broadcasted = FrozenDate::now()->subDay(21);
+        $this->assertFalse($this->RetentionHistory->isRecent());
+    }
+
+    /**
+     * Test isRecent method if `broadcasted` field not has value
+     *
+     * @return void
+     */
+    public function testIsRecentNoHasBroadcasted()
     {
         $this->RetentionHistory->acquired = FrozenDate::now();
         $this->assertTrue($this->RetentionHistory->isRecent());


### PR DESCRIPTION
### 概要

- タイトル保持履歴に放映日を追加

### 対応内容

- `retention_histories.broadcasted` を追加
- 「履歴データが新しいか」を判定する処理で、上記に値が入っている場合はその値を利用するよう修正