### PR TITLE
merges #772

### DIFF
--- a/resources/assets/styles/view.scss
+++ b/resources/assets/styles/view.scss
@@ -54,6 +54,15 @@
     margin: 0.5rem 0.7rem;
     width: calc(100% - (0.7rem * 2));
 
+    &-inner-box {
+      @for $sep from 1 through 12 {
+        &-#{$sep} {
+          flex-basis: calc(100% / 12 * #{$sep});
+          width: calc(100% / 12 * #{$sep});
+        }
+      }
+    }
+
     &.dropdowns {
       display: inline-block;
       width: auto;

--- a/resources/assets/styles/view.scss
+++ b/resources/assets/styles/view.scss
@@ -68,6 +68,10 @@
       width: auto;
     }
   }
+
+  .retention-row {
+    @include flex-justify-start();
+  }
 }
 
 .detail-dialog {

--- a/src/Model/Entity/Country.php
+++ b/src/Model/Entity/Country.php
@@ -11,7 +11,6 @@ use Cake\ORM\TableRegistry;
  * @property string $code
  * @property string $name
  * @property string $name_english
- * @property string $label
  * @property bool $has_title
  * @property \Cake\I18n\FrozenTime $created
  * @property \Cake\I18n\FrozenTime $modified
@@ -49,15 +48,5 @@ class Country extends AppEntity
     public function isWorlds()
     {
         return !$this->has_title;
-    }
-
-    /**
-     * 表示用のラベルを取得します。
-     *
-     * @return string ラベル
-     */
-    protected function _getLabel()
-    {
-        return "（{$this->name}棋戦）";
     }
 }

--- a/src/Model/Entity/Player.php
+++ b/src/Model/Entity/Player.php
@@ -196,7 +196,9 @@ class Player extends AppEntity
             return collection([]);
         }
 
-        $result = TableRegistry::getTableLocator()->get('RetentionHistories')->findHistoriesByPlayer($this->id);
+        /** @var \Gotea\Model\Table\RetentionHistoriesTable $table */
+        $table = TableRegistry::getTableLocator()->get('RetentionHistories');
+        $result = $table->findHistoriesByPlayer($this->id);
 
         return $this->retention_histories = $result;
     }
@@ -259,11 +261,15 @@ class Player extends AppEntity
     /**
      * 年度単位でグループ化します。
      *
-     * @return \Gotea\Model\Entity\Cake\Collection\Collection
+     * @return \Cake\Collection\Collection
      */
     public function groupByYearFromHistories()
     {
-        return $this->retention_histories->groupBy('target_year');
+        return $this->retention_histories
+            ->groupBy('target_year')
+            ->map(function ($items) {
+                return collection($items)->groupBy('title.country.name');
+            });
     }
 
     /**

--- a/src/Model/Entity/RetentionHistory.php
+++ b/src/Model/Entity/RetentionHistory.php
@@ -25,23 +25,12 @@ namespace Gotea\Model\Entity;
  * @property \Gotea\Model\Entity\Country|null $country
  * @property \Gotea\Model\Entity\Rank|null $rank
  *
- * @property string $team_label
  * @property string $winner_name
  */
 class RetentionHistory extends AppEntity
 {
     use PlayerTrait;
     use RankTrait;
-
-    /**
-     * 団体戦判定結果を取得します。
-     *
-     * @return string
-     */
-    protected function _getTeamLabel()
-    {
-        return __($this->is_team ? '（団体戦）' : '（個人戦）');
-    }
 
     /**
      * タイトル保持者を取得します。

--- a/src/Model/Table/RetentionHistoriesTable.php
+++ b/src/Model/Table/RetentionHistoriesTable.php
@@ -155,7 +155,7 @@ class RetentionHistoriesTable extends AppTable
             ->order([
                 'RetentionHistories.target_year' => 'DESC',
                 'Titles.country_id' => 'ASC',
-                'Titles.sort_order' => 'ASC',
+                'RetentionHistories.acquired' => 'ASC',
             ]);
     }
 

--- a/templates/element/Players/retention_histories.php
+++ b/templates/element/Players/retention_histories.php
@@ -5,22 +5,34 @@
  */
 ?>
 <section data-contentname="retention_histories" class="tab-contents">
-    <div class="page-header">タイトル取得履歴<?= !$player->isNew() ? ' (ID: '. h($player->id) . ')' : '' ?></div>
+    <div class="page-header">タイトル取得履歴<?= !$player->isNew() ? ' (ID: ' . h($player->id) . ')' : '' ?></div>
     <?php $histories = $player->groupByYearFromHistories(); ?>
-    <?php foreach ($histories as $key => $items) : ?>
-        <?php $unOfficialCount = count(array_filter($items, function ($item) {
-            return !$item->is_official;
-        })); ?>
-        <?php $titleCount = count($items) . ($unOfficialCount > 0 ? " (非公式{$unOfficialCount})" : '') ?>
-        <div class="label-row"><?= __('{0}年度: {1}', $key, $titleCount) ?></div>
-        <?php foreach ($items as $item) : ?>
+    <?php foreach ($histories as $key => $countries) : ?>
+        <?php
+            $unOfficialCount = $countries->sumOf(function ($items) {
+                return count(array_filter($items, function ($item) {
+                    return !$item->is_official;
+                }));
+            });
+            $titleCount = $countries->sumOf(function ($items) {
+                return count($items);
+            });
+            $titleLabel = $titleCount . ($unOfficialCount > 0 ? " (非公式戦{$unOfficialCount})" : '');
+        ?>
+        <div class="label-row"><?= __('{0}年度: {1}', $key, $titleLabel) ?></div>
+        <?php foreach ($countries as $country => $items) : ?>
             <div class="input-row">
-                <span class="inner-column"><?= __('{0}期', $item->holding) ?></span>
-                <span class="inner-column"><?= h($item->name) ?></span>
-                <span class="inner-column"><?= h($item->title->country->label) ?></span>
-                <?php if (!$item->is_official) : ?>
-                    <span class="inner-column">（非公式戦）</span>
-                <?php endif ?>
+                <div class="input-row-inner-box input-row-inner-box-2">
+                    <?= h($country) . '棋戦' ?>
+                </div>
+                <div class="input-row-inner-box input-row-inner-box-10">
+                    <?php
+                        $label = implode(' / ', array_map(function ($history) {
+                            return '第' . $history->holding . '期 ' . $history->name . (!$history->is_official ? '（非公式戦）' : '');
+                        }, $items));
+                    ?>
+                    <span><?= h($label) ?></span>
+                </div>
             </div>
         <?php endforeach ?>
     <?php endforeach ?>

--- a/templates/element/Players/retention_histories.php
+++ b/templates/element/Players/retention_histories.php
@@ -28,10 +28,14 @@
                 <div class="input-row-inner-box input-row-inner-box-10">
                     <?php
                         $label = implode(' / ', array_map(function ($history) {
-                            return '第' . $history->holding . '期 ' . $history->name . (!$history->is_official ? '（非公式戦）' : '');
+                            $holding = h('第' . $history->holding . '期 ');
+                            $acquiredMonth = h('(' . $this->Date->format($history->acquired, 'M月d日') . ')');
+
+                            return $holding . $this->Html->link($history->name, ['_name' => 'view_title', $history->title_id])
+                                . $acquiredMonth . (!$history->is_official ? '（非公式戦）' : '');
                         }, $items));
                     ?>
-                    <span><?= h($label) ?></span>
+                    <span><?= $label ?></span>
                 </div>
             </div>
         <?php endforeach ?>

--- a/templates/element/Titles/retention_histories.php
+++ b/templates/element/Titles/retention_histories.php
@@ -19,54 +19,16 @@ $isAdmin = $this->isAdmin();
     <?php endif ?>
     <ul class="boxes">
         <?php if (!empty($title->retention_histories)) : ?>
-            <?php if (($retention = $title->now_retention)) : ?>
+            <?php
+                $retention = $title->now_retention;
+            ?>
+            <?php if ($retention) : ?>
                 <li class="label-row">現在の保持情報</li>
-                <li class="detail_box">
-                    <div class="detail_box_item box-10">
-                        <span class="inner-column"><?= h($retention->target_year) . '年' ?></span>
-                        <span class="inner-column"><?= h($retention->holding) . '期' ?></span>
-                        <span class="inner-column"><span>タイトル名：</span><?= h($retention->name) ?></span>
-                        <span class="inner-column"><?= h($retention->team_label) ?></span>
-                        <span class="inner-column"><span>優勝者：</span><?= h($retention->winner_name) ?></span>
-                        <?php if ($title->country->isWorlds() && !$retention->is_team) : ?>
-                        <span class="inner-column"><span>出場国：</span><?= h($retention->country->name) ?></span>
-                        <?php endif ?>
-                        <?php if (!$retention->is_official) : ?>
-                            <span class="inner-column">（非公式戦）</span>
-                        <?php endif ?>
-                        <?php if ($retention->isRecent()) : ?>
-                            <span class="inner-column"><span class="mark-new">NEW!</span></span>
-                        <?php endif ?>
-                    </div>
-                    <?php if ($isAdmin) : ?>
-                    <div class="detail_box_item detail_box_item-buttons box-2">
-                        <button type="button" class="button button-secondary" value="edit" @click="select('<?= $retention->id ?>')">編集</button>
-                    </div>
-                    <?php endif ?>
-                </li>
+                <?= $this->element('Titles/retention_history_item', ['isAdmin' => $isAdmin, 'retention' => $retention]) ?>
             <?php endif ?>
             <li class="label-row">保持情報（履歴）</li>
             <?php foreach ($title->histories as $history) : ?>
-                <li class="detail_box">
-                    <div class="detail_box_item box-10">
-                        <span class="inner-column"><?= h($history->target_year) . '年' ?></span>
-                        <span class="inner-column"><?= h($history->holding) . '期' ?></span>
-                        <span class="inner-column"><span>タイトル名：</span><?= h($history->name) ?></span>
-                        <span class="inner-column"><?= h($history->team_label) ?></span>
-                        <span class="inner-column"><span>優勝者：</span><?= h($history->winner_name) ?></span>
-                        <?php if ($title->country->isWorlds() && !$history->is_team) : ?>
-                        <span class="inner-column"><span>出場国：</span><?= h($history->country->name) ?></span>
-                        <?php endif ?>
-                        <?php if (!$history->is_official) : ?>
-                            <span class="inner-column">（非公式戦）</span>
-                        <?php endif ?>
-                    </div>
-                    <?php if ($isAdmin) : ?>
-                    <div class="detail_box_item detail_box_item-buttons box-2">
-                        <button type="button" class="button button-secondary" value="edit" @click="select('<?= $history->id ?>')">編集</button>
-                    </div>
-                    <?php endif ?>
-                </li>
+                <?= $this->element('Titles/retention_history_item', ['isAdmin' => $isAdmin, 'retention' => $history]) ?>
             <?php endforeach ?>
         <?php endif ?>
     </ul>

--- a/templates/element/Titles/retention_history_item.php
+++ b/templates/element/Titles/retention_history_item.php
@@ -15,7 +15,7 @@
         <?php endif ?>
     </div>
     <div class="detail_box_item box-1">
-        <?= !$retention->is_official ? '（非公式戦）' : '（公式戦）' ?>
+        <?= !$retention->is_official ? '非公式戦' : '公式戦' ?>
     </div>
     <div class="detail_box_item box-2">
         <span class="inner-column">

--- a/templates/element/Titles/retention_history_item.php
+++ b/templates/element/Titles/retention_history_item.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @var \Gotea\View\AppView $this
+ * @var \Gotea\Model\Entity\RetentionHistory $retention
+ */
+?>
+<li class="retention-row">
+    <div class="detail_box_item box-2">
+        <?php
+            $label = '第' . $retention->holding . '期(' . $retention->target_year . '年)';
+        ?>
+        <span class="inner-column"><?= h($label) ?></span>
+        <?php if ($retention->isRecent()) : ?>
+            <span><span class="mark-new">NEW!</span></span>
+        <?php endif ?>
+    </div>
+    <div class="detail_box_item box-1">
+        <?= !$retention->is_official ? '（非公式戦）' : '（公式戦）' ?>
+    </div>
+    <div class="detail_box_item box-2">
+        <span class="inner-column">
+            <?= $this->Date->format($retention->acquired, 'yyyy年M月d日') . '優勝' ?>
+            <?php if ($retention->broadcasted) : ?>
+                <br/><?= '(' . $this->Date->format($retention->broadcasted, 'yyyy年M月d日') . '放映)' ?>
+            <?php endif ?>
+        </span>
+    </div>
+    <div class="detail_box_item box-5">
+        <?php
+            $winner = $title->country->isWorlds() && !$retention->is_team
+                ? $retention->country->name
+                : $retention->winner_name . '(' . $retention->country->name . ')';
+        ?>
+        <span class="inner-column"><?= h($winner) ?></span>
+    </div>
+    <?php if ($isAdmin) : ?>
+    <div class="detail_box_item detail_box_item-buttons box-2">
+        <button
+            type="button"
+            class="button button-secondary"
+            value="edit"
+            @click="select('<?= $retention->id ?>')"
+        >編集</button>
+    </div>
+    <?php endif ?>
+</li>


### PR DESCRIPTION
### 概要

- retention_histories テーブルのデータを表示する箇所のレイアウト修正

### 対応内容

- 棋士詳細 > タイトル取得情報
  - 棋戦の開催元（日本棋戦とか）単位にグルーピングして表示
  - 取得日を表示し、この昇順で並ぶように変更
  - タイトル名にタイトル詳細ページへのリンクを追加
- タイトル詳細 > 保持履歴
  - 取得日・放映日を表示
  - 公式戦の場合もラベル `（公式戦） `を表示
  - 表示箇所を element 化し、現在の保持情報・履歴で同じ項目を表示するよう対応