### PR TITLE
refs #554

### DIFF
--- a/src/Controller/Api/ApiController.php
+++ b/src/Controller/Api/ApiController.php
@@ -22,6 +22,13 @@ abstract class ApiController extends Controller
     {
         parent::initialize();
 
+        $this->loadComponent('Authentication.Authentication', [
+            'logoutRedirect' => [
+                '_name' => 'top',
+            ],
+        ]);
+        $this->loadComponent('Authorization.Authorization');
+
         $this->forceJsonResponse();
 
         // 操作ユーザ記録イベントを設定

--- a/tests/TestCase/Controller/Api/ApiTestCase.php
+++ b/tests/TestCase/Controller/Api/ApiTestCase.php
@@ -3,16 +3,13 @@ declare(strict_types=1);
 
 namespace Gotea\Test\TestCase\Controller\Api;
 
-use Cake\TestSuite\IntegrationTestTrait;
-use Cake\TestSuite\TestCase;
+use Gotea\Test\TestCase\Controller\AppTestCase;
 
 /**
  * APIテスト時の共通コントローラ
  */
-abstract class ApiTestCase extends TestCase
+abstract class ApiTestCase extends AppTestCase
 {
-    use IntegrationTestTrait;
-
     /**
      * データなしレスポンス
      *

--- a/tests/TestCase/Controller/Api/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/Api/PlayersControllerTest.php
@@ -29,6 +29,15 @@ class PlayersControllerTest extends ApiTestCase
     ];
 
     /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->createSession();
+    }
+
+    /**
      * 棋士と段位の一覧取得（不正パラメータ）
      *
      * @return void

--- a/tests/TestCase/Controller/Api/RanksControllerTest.php
+++ b/tests/TestCase/Controller/Api/RanksControllerTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Gotea\Controller\Api\RanksController Test Case
  */
-class RanksControllerTest extends TestCase
+class RanksControllerTest extends ApiTestCase
 {
     use IntegrationTestTrait;
 
@@ -21,6 +21,15 @@ class RanksControllerTest extends TestCase
     public $fixtures = [
         'app.Ranks',
     ];
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->createSession();
+    }
 
     /**
      * Test index method

--- a/tests/TestCase/Controller/Api/RanksControllerTest.php
+++ b/tests/TestCase/Controller/Api/RanksControllerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Gotea\Test\TestCase\Controller\Api;
 
 use Cake\TestSuite\IntegrationTestTrait;
-use Cake\TestSuite\TestCase;
 
 /**
  * Gotea\Controller\Api\RanksController Test Case

--- a/tests/TestCase/Controller/Api/TitlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/TitlesControllerTest.php
@@ -23,6 +23,15 @@ class TitlesControllerTest extends ApiTestCase
     ];
 
     /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->createSession();
+    }
+
+    /**
      * タイトル一覧取得
      *
      * @return void


### PR DESCRIPTION
### 概要

- api へのアクセスをトークン必須とするため、まず api へのアクセスはログイン済みであることを前提とするように修正
