### PR TITLE
merges #902

### DIFF
--- a/resources/assets/styles/modules/_title-scores.scss
+++ b/resources/assets/styles/modules/_title-scores.scss
@@ -3,6 +3,10 @@
  ------------------------------------------- */
 .title-scores {
   .search-header {
+    .name {
+      width: 200px;
+    }
+
     .started {
       margin-right: 0.5rem;
       width: 120px;

--- a/templates/TitleScores/index.php
+++ b/templates/TitleScores/index.php
@@ -10,10 +10,17 @@
         <ul class="search-header">
             <li class="search-row">
                 <div class="search-box">
-                    <?= $this->Form->control('name', [
-                        'label' => ['text' => '棋士名'],
+                    <?= $this->Form->control('name1', [
+                        'label' => ['text' => '棋士名1'],
                         'class' => 'name',
-                        'value' => $this->getRequest()->getQuery('name'),
+                        'value' => $this->getRequest()->getQuery('name1'),
+                    ]) ?>
+                </div>
+                <div class="search-box">
+                    <?= $this->Form->control('name2', [
+                        'label' => ['text' => '棋士名2'],
+                        'class' => 'name',
+                        'value' => $this->getRequest()->getQuery('name2'),
                     ]) ?>
                 </div>
                 <div class="search-box">

--- a/tests/TestCase/Model/Table/TitleScoresTableTest.php
+++ b/tests/TestCase/Model/Table/TitleScoresTableTest.php
@@ -243,19 +243,33 @@ class TitleScoresTableTest extends TestCase
             $this->assertEquals($item->ended->year, $year);
         });
 
-        // 棋士名
-        $name = 'test1 test2';
+        // 棋士名（1件）
+        $name1 = 'test1';
         $scores = $this->TitleScores->findMatches([
-            'name' => $name,
+            'name1' => $name1,
         ]);
         $this->assertGreaterThan(0, $scores->count());
-        $names = explode(' ', $name);
-        $scores->each(function ($item) use ($names) {
-            $this->assertTrue(collection($names)
-                ->some(function ($value) use ($item) {
-                    return strpos($item->winner_name, $value) !== false
-                        || strpos($item->loser_name, $value) !== false;
-                }));
+        $scores->each(function ($item) use ($name1) {
+            $this->assertTrue(
+                strpos($item->winner_name, $name1) !== false || strpos($item->loser_name, $name1) !== false,
+            );
+        });
+
+        // 棋士名（2件）
+        $name1 = 'test1';
+        $name2 = 'test2';
+        $scores = $this->TitleScores->findMatches([
+            'name1' => $name1,
+            'name2' => $name2,
+        ]);
+        $this->assertGreaterThan(0, $scores->count());
+        $scores->each(function ($item) use ($name1, $name2) {
+            $this->assertTrue(
+                strpos($item->winner_name, $name1) !== false || strpos($item->loser_name, $name1) !== false,
+            );
+            $this->assertTrue(
+                strpos($item->winner_name, $name2) !== false || strpos($item->loser_name, $name2) !== false,
+            );
         });
 
         // タイトル名


### PR DESCRIPTION
### 概要

- タイトル成績の棋士名検索条件変更

### 対応内容

- inner join ではなく exists で処理するよう修正
- もともとは「棋士A・Bの対戦成績を知りたい」という意図で実装した機能なので、1つのフィールドに入力された値を or 検索するのではなく、複数のフィールドに入力された値を用いて exists するよう修正