### PR TITLE
merges #959 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,16 +41,13 @@ jobs:
 
   code_check_php:
     docker:
-      - image: circleci/php:7.4
+      - image: gotoeveryone/composer-php:7.4
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN
     working_directory: ~/gotea
     steps:
       - checkout
-      - run: sudo apt install -y zlib1g-dev
-      - run: sudo docker-php-ext-install zip
-      - run: sudo composer self-update
       - restore_cache:
           <<: *restore_composer_cache
       - run: composer install -n --prefer-dist
@@ -60,7 +57,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/php:7.4
+      - image: gotoeveryone/composer-php:7.4
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -73,9 +70,6 @@ jobs:
     working_directory: ~/gotea
     steps:
       - checkout
-      - run: sudo apt install -y zlib1g-dev
-      - run: sudo docker-php-ext-install zip pdo_mysql
-      - run: sudo composer self-update
       - restore_cache:
           <<: *restore_composer_cache
       - run: composer install -n --prefer-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.0
 
 references:
   save_composer_cache: &save_composer_cache
@@ -71,6 +71,17 @@ jobs:
     working_directory: ~/gotea
     steps:
       - checkout
+      - run:
+          name: install dockerize
+          command: |
+            curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz -O
+            tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:3306 -timeout 1m
       - restore_cache:
           <<: *restore_composer_cache
       - run: composer install -n --prefer-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN
         environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
           MYSQL_DATABASE: gotea_test
     working_directory: ~/gotea
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: '3'
 services:
   backend:
-    build: ./docker/app
-    image: gotea/server:latest
+    image: gotoeveryone/composer-php:7.4
     volumes:
       - ./:/src
       - vendor:/src/vendor

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,7 +1,0 @@
-FROM php:7.4
-
-RUN apt-get -y update && \
-  apt-get install -y libicu-dev libzip-dev && \
-  docker-php-ext-install zip pdo_mysql intl
-
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
### 概要

- backend コンテナが利用するイメージを DockerHub から取得するように

### 対応内容

- `docker build -t gotoeveryone/composer-php:7.4 ./docker/app` でイメージを作成
- `docker push gotoeveryone/composer-php:7.4` でイメージを DockerHub へ Push
- docker-compose.yml で上記イメージを利用するよう修正
