### PR TITLE
composer install 時に .env の作成を行う

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ API_URL=""
 DB_HOST="database"
 DB_PORT=3306
 DB_NAME="gotea"
-DB_USERNAME="forge"
-DB_PASSWORD="forge"
+DB_USERNAME="root"
+DB_PASSWORD=""
 DB_ENCODING="utf8mb4"
 DB_TIMEZONE="Asia/Tokyo"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,14 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.vendor_cache.outputs.cache-hit != 'true' }}
         run: composer install
-      - name: Execute setup
-        run: cp .env.example .env
       - name: Execute test
         run: composer test
 
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     env:
-      TAR_NAME: "gotea_${{ github.run_number }}.tar.gz"
-      SHELL_DEST_PATH: "~/deploy_${{ github.run_number }}.sh"
+      TAR_NAME: 'gotea_${{ github.run_number }}.tar.gz'
+      SHELL_DEST_PATH: '~/deploy_${{ github.run_number }}.sh'
     runs-on: ubuntu-latest
     needs:
       - code_check_backend

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -47,12 +47,11 @@ use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
 
 /**
- * Read .env file if APP_NAME is not set.
+ * Read .env file.
  *
  * You can remove this block if you do not want to use environment
  * variables for configuration when deploying.
  */
-// .envファイル読み込み
 try {
     (new Dotenv(ROOT))->overload();
 } catch (InvalidPathException $e) {

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -94,11 +94,11 @@ class Installer
      */
     public static function createAppConfig($dir, $io)
     {
-        $appConfig = $dir . '/config/app.php';
-        $defaultConfig = $dir . '/config/app.default.php';
-        if (!file_exists($appConfig)) {
-            copy($defaultConfig, $appConfig);
-            $io->write('Created `config/app.php` file');
+        $appLocalConfig = $dir . '/.env';
+        $appLocalConfigTemplate = $dir . '/.env.example';
+        if (!file_exists($appLocalConfig)) {
+            copy($appLocalConfigTemplate, $appLocalConfig);
+            $io->write('Created `.env` file');
         }
     }
 
@@ -177,7 +177,7 @@ class Installer
     public static function setSecuritySalt($dir, $io)
     {
         $newKey = hash('sha256', Security::randomBytes(64));
-        static::setSecuritySaltInFile($dir, $io, $newKey, 'app.php');
+        static::setSecuritySaltInFile($dir, $io, $newKey, '.env');
     }
 
     /**
@@ -191,7 +191,7 @@ class Installer
      */
     public static function setSecuritySaltInFile($dir, $io, $newKey, $file)
     {
-        $config = $dir . '/config/' . $file;
+        $config = $dir . '/' . $file;
         $content = file_get_contents($config);
 
         $content = str_replace('__SALT__', $newKey, $content, $count);
@@ -204,7 +204,7 @@ class Installer
 
         $result = file_put_contents($config, $content);
         if ($result) {
-            $io->write('Updated Security.salt value in config/' . $file);
+            $io->write('Updated Security.salt value in ' . $file);
 
             return;
         }
@@ -222,7 +222,7 @@ class Installer
      */
     public static function setAppNameInFile($dir, $io, $appName, $file)
     {
-        $config = $dir . '/config/' . $file;
+        $config = $dir . '/' . $file;
         $content = file_get_contents($config);
         $content = str_replace('__APP_NAME__', $appName, $content, $count);
 
@@ -234,7 +234,7 @@ class Installer
 
         $result = file_put_contents($config, $content);
         if ($result) {
-            $io->write('Updated __APP_NAME__ value in config/' . $file);
+            $io->write('Updated __APP_NAME__ value in ' . $file);
 
             return;
         }


### PR DESCRIPTION
### 概要

- 件名の通り

### 対応内容

- composer install 時に .env.example から .env の作成を行うよう対応
- 合わせて `__SALT__` を生成したセキュリティソルトで置き換える
