### PR TITLE
merges #987

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "abraham/twitteroauth": "^1.1",
     "cakephp/authentication": "^2.0",
     "cakephp/authorization": "^2.0",
-    "cakephp/cakephp": "4.0.*",
-    "cakephp/migrations": "^3.0",
+    "cakephp/cakephp": "^4.3",
+    "cakephp/migrations": "^3.2",
     "cakephp/plugin-installer": "^1.0",
     "connehito/cake-sentry": "^4.0",
     "dereuromark/cakephp-shim": "^2.0",
@@ -53,8 +53,8 @@
       "@test",
       "@cs-check"
     ],
-    "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
-    "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
+    "cs-check": "phpcs --colors -p  src/ tests/",
+    "cs-fix": "phpcbf --colors -p src/ tests/",
     "test": "phpunit --colors=always"
   },
   "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceae7e45ec005af394f6d076cd8fbc8f",
+    "content-hash": "aa6d539d0b35aa15436b4343df2e596a",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -66,56 +66,6 @@
                 "source": "https://github.com/abraham/twitteroauth"
             },
             "time": "2020-09-22T14:27:00+00:00"
-        },
-        {
-            "name": "aura/intl",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/auraphp/Aura.Intl.git",
-                "reference": "7fce228980b19bf4dee2d7bbd6202a69b0dde926"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/auraphp/Aura.Intl/zipball/7fce228980b19bf4dee2d7bbd6202a69b0dde926",
-                "reference": "7fce228980b19bf4dee2d7bbd6202a69b0dde926",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Aura\\Intl\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aura.Intl Contributors",
-                    "homepage": "https://github.com/auraphp/Aura.Intl/contributors"
-                }
-            ],
-            "description": "The Aura Intl package provides internationalization tools, specifically message translation.",
-            "homepage": "https://github.com/auraphp/Aura.Intl",
-            "keywords": [
-                "g11n",
-                "globalization",
-                "i18n",
-                "internationalization",
-                "intl",
-                "l10n",
-                "localization"
-            ],
-            "support": {
-                "issues": "https://github.com/auraphp/Aura.Intl/issues",
-                "source": "https://github.com/auraphp/Aura.Intl/tree/3.x"
-            },
-            "time": "2017-01-20T05:00:11+00:00"
         },
         {
             "name": "cakephp/authentication",
@@ -253,28 +203,29 @@
         },
         {
             "name": "cakephp/cakephp",
-            "version": "4.0.10",
+            "version": "4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "5c6d72bc9bb1be6eec1b00b3930f9e5054ee6d76"
+                "reference": "9bfef5659088c446b2f7bdb612cc321d83779287"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/5c6d72bc9bb1be6eec1b00b3930f9e5054ee6d76",
-                "reference": "5c6d72bc9bb1be6eec1b00b3930f9e5054ee6d76",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/9bfef5659088c446b2f7bdb612cc321d83779287",
+                "reference": "9bfef5659088c446b2f7bdb612cc321d83779287",
                 "shasum": ""
             },
             "require": {
-                "aura/intl": "^3.0.0",
-                "cakephp/chronos": "^2.0",
+                "cakephp/chronos": "^2.2",
                 "composer/ca-bundle": "^1.2",
                 "ext-intl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "laminas/laminas-diactoros": "^2.2.2",
                 "laminas/laminas-httphandlerrunner": "^1.1",
+                "league/container": "^4.2.0",
                 "php": ">=7.2.0",
+                "psr/container": "^1.1 || ^2.0",
                 "psr/http-client": "^1.0",
                 "psr/http-server-handler": "^1.0",
                 "psr/http-server-middleware": "^1.0",
@@ -299,10 +250,10 @@
                 "cakephp/validation": "self.version"
             },
             "require-dev": {
-                "cakephp/cakephp-codesniffer": "^4.0",
-                "mikey179/vfsstream": "^1.6",
+                "cakephp/cakephp-codesniffer": "^4.5",
+                "mikey179/vfsstream": "^1.6.10",
                 "paragonie/csp-builder": "^2.3",
-                "phpunit/phpunit": "~8.5.0"
+                "phpunit/phpunit": "^8.5 || ^9.3"
             },
             "suggest": {
                 "ext-curl": "To enable more efficient network calls in Http\\Client.",
@@ -319,6 +270,7 @@
                     "src/Core/functions.php",
                     "src/Collection/functions.php",
                     "src/I18n/functions.php",
+                    "src/Routing/functions.php",
                     "src/Utility/bootstrap.php"
                 ]
             },
@@ -351,29 +303,28 @@
                 "issues": "https://github.com/cakephp/cakephp/issues",
                 "source": "https://github.com/cakephp/cakephp"
             },
-            "time": "2020-12-08T03:04:12+00:00"
+            "time": "2021-12-17T16:07:12+00:00"
         },
         {
             "name": "cakephp/chronos",
-            "version": "2.0.6",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/chronos.git",
-                "reference": "30baea51824076719921c6c2d720bfd6b49e6dca"
+                "reference": "3ecd6e7ae191c676570cd1bed51fd561de4606dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/chronos/zipball/30baea51824076719921c6c2d720bfd6b49e6dca",
-                "reference": "30baea51824076719921c6c2d720bfd6b49e6dca",
+                "url": "https://api.github.com/repos/cakephp/chronos/zipball/3ecd6e7ae191c676570cd1bed51fd561de4606dd",
+                "reference": "3ecd6e7ae191c676570cd1bed51fd561de4606dd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "cakephp/cakephp-codesniffer": "^4.0",
-                "phpbench/phpbench": "^1.0@dev",
-                "phpunit/phpunit": "^8.0"
+                "cakephp/cakephp-codesniffer": "^4.5",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "autoload": {
@@ -411,33 +362,33 @@
                 "issues": "https://github.com/cakephp/chronos/issues",
                 "source": "https://github.com/cakephp/chronos"
             },
-            "time": "2020-08-22T02:42:12+00:00"
+            "time": "2021-10-17T02:44:05+00:00"
         },
         {
             "name": "cakephp/migrations",
-            "version": "3.0.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/migrations.git",
-                "reference": "a41a44e726dcc3634db0c2ac6bc4e158e416d103"
+                "reference": "42704263a216dbe33fe41ddbe0780769b1c864be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/migrations/zipball/a41a44e726dcc3634db0c2ac6bc4e158e416d103",
-                "reference": "a41a44e726dcc3634db0c2ac6bc4e158e416d103",
+                "url": "https://api.github.com/repos/cakephp/migrations/zipball/42704263a216dbe33fe41ddbe0780769b1c864be",
+                "reference": "42704263a216dbe33fe41ddbe0780769b1c864be",
                 "shasum": ""
             },
             "require": {
-                "cakephp/cache": "^4.0.5",
-                "cakephp/orm": "^4.0.5",
+                "cakephp/cache": "^4.3.0",
+                "cakephp/orm": "^4.3.0",
                 "php": ">=7.2.0",
                 "robmorgan/phinx": "^0.12"
             },
             "require-dev": {
-                "cakephp/bake": "^2.1.0",
-                "cakephp/cakephp": "^4.0.5",
-                "cakephp/cakephp-codesniffer": "~4.1.0",
-                "phpunit/phpunit": "~8.5.0"
+                "cakephp/bake": "^2.6.0",
+                "cakephp/cakephp": "^4.3.0",
+                "cakephp/cakephp-codesniffer": "^4.1",
+                "phpunit/phpunit": "^8.5.0 || ^9.5.0"
             },
             "suggest": {
                 "cakephp/bake": "If you want to generate migrations.",
@@ -471,7 +422,7 @@
                 "issues": "https://github.com/cakephp/migrations/issues",
                 "source": "https://github.com/cakephp/migrations"
             },
-            "time": "2020-05-10T22:26:04+00:00"
+            "time": "2021-11-29T16:23:04+00:00"
         },
         {
             "name": "cakephp/plugin-installer",
@@ -590,16 +541,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.11",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "0b072d51c5a9c6f3412f7ea3ab043d6603cb2582"
+                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/0b072d51c5a9c6f3412f7ea3ab043d6603cb2582",
-                "reference": "0b072d51c5a9c6f3412f7ea3ab043d6603cb2582",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
+                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
                 "shasum": ""
             },
             "require": {
@@ -646,7 +597,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.11"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.1"
             },
             "funding": [
                 {
@@ -662,7 +613,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-25T20:32:43+00:00"
+            "time": "2021-10-28T20:44:15+00:00"
         },
         {
             "name": "connehito/cake-sentry",
@@ -1090,21 +1041,21 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.4.1",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "36ef09b73e884135d2059cc498c938e90821bb57"
+                "reference": "7d2034110ae18afe05050b796a3ee4b3fe177876"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/36ef09b73e884135d2059cc498c938e90821bb57",
-                "reference": "36ef09b73e884135d2059cc498c938e90821bb57",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/7d2034110ae18afe05050b796a3ee4b3fe177876",
+                "reference": "7d2034110ae18afe05050b796a3ee4b3fe177876",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.1",
+                "php": "^7.3 || ~8.0.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
@@ -1123,10 +1074,13 @@
                 "ext-dom": "*",
                 "ext-gd": "*",
                 "ext-libxml": "*",
-                "http-interop/http-factory-tests": "^0.5.0",
+                "http-interop/http-factory-tests": "^0.8.0",
                 "laminas/laminas-coding-standard": "~1.0.0",
-                "php-http/psr7-integration-tests": "^1.0",
-                "phpunit/phpunit": "^7.5.18"
+                "php-http/psr7-integration-tests": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.1",
+                "psalm/plugin-phpunit": "^0.14.0",
+                "vimeo/psalm": "^4.3"
             },
             "type": "library",
             "extra": {
@@ -1185,25 +1139,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-09-03T14:29:41+00:00"
+            "time": "2021-05-18T14:41:54+00:00"
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
-            "version": "1.2.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-                "reference": "e1a5dad040e0043135e8095ee27d1fbf6fb640e1"
+                "reference": "5f94e55d93f756e8ad07b9049aeb3d6d84582d0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/e1a5dad040e0043135e8095ee27d1fbf6fb640e1",
-                "reference": "e1a5dad040e0043135e8095ee27d1fbf6fb640e1",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/5f94e55d93f756e8ad07b9049aeb3d6d84582d0e",
+                "reference": "5f94e55d93f756e8ad07b9049aeb3d6d84582d0e",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.1",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
                 "psr/http-message": "^1.0",
                 "psr/http-message-implementation": "^1.0",
                 "psr/http-server-handler": "^1.0"
@@ -1213,15 +1167,13 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-diactoros": "^1.7 || ^2.1.1",
-                "phpunit/phpunit": "^7.0.2"
+                "laminas/laminas-diactoros": "^2.8.0",
+                "phpunit/phpunit": "^9.5.9",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.10.0"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev",
-                    "dev-develop": "1.3.x-dev"
-                },
                 "laminas": {
                     "config-provider": "Laminas\\HttpHandlerRunner\\ConfigProvider"
                 }
@@ -1258,28 +1210,30 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-06-03T15:52:17+00:00"
+            "time": "2021-09-22T09:17:54+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.1.1",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
+                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
             },
             "type": "library",
             "extra": {
@@ -1318,7 +1272,89 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-09-14T14:23:00+00:00"
+            "time": "2021-12-21T14:34:37+00:00"
+        },
+        {
+            "name": "league/container",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "375d13cb828649599ef5d48a339c4af7a26cd0ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/375d13cb828649599ef5d48a339c4af7a26cd0ab",
+                "reference": "375d13cb828649599ef5d48a339c4af7a26cd0ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "nette/php-generator": "^3.4",
+                "nikic/php-parser": "^4.10",
+                "phpstan/phpstan": "^0.12.47",
+                "phpunit/phpunit": "^8.5.17",
+                "roave/security-advisories": "dev-latest",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "mail@philbennett.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/4.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-16T10:29:06+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -1768,22 +1804,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1810,9 +1851,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/http-client",
@@ -2235,30 +2276,30 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "0.12.4",
+            "version": "0.12.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "05902f4a90790ce9db195954e608d5a43d4d6a7d"
+                "reference": "5a0146a74c1bc195d1f5da86afa3b68badf7d90e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/05902f4a90790ce9db195954e608d5a43d4d6a7d",
-                "reference": "05902f4a90790ce9db195954e608d5a43d4d6a7d",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/5a0146a74c1bc195d1f5da86afa3b68badf7d90e",
+                "reference": "5a0146a74c1bc195d1f5da86afa3b68badf7d90e",
                 "shasum": ""
             },
             "require": {
                 "cakephp/database": "^4.0",
                 "php": ">=7.2",
-                "psr/container": "^1.0",
+                "psr/container": "^1.0 || ^2.0",
                 "symfony/config": "^3.4|^4.0|^5.0",
                 "symfony/console": "^3.4|^4.0|^5.0"
             },
             "require-dev": {
-                "cakephp/cakephp-codesniffer": "^3.0",
+                "cakephp/cakephp-codesniffer": "^4.0",
                 "ext-json": "*",
                 "ext-pdo": "*",
-                "phpunit/phpunit": "^8.5",
+                "phpunit/phpunit": "^8.5|^9.3",
                 "sebastian/comparator": ">=1.2.3",
                 "symfony/yaml": "^3.4|^4.0|^5.0"
             },
@@ -2315,9 +2356,9 @@
             ],
             "support": {
                 "issues": "https://github.com/cakephp/phinx/issues",
-                "source": "https://github.com/cakephp/phinx/tree/master"
+                "source": "https://github.com/cakephp/phinx/tree/0.12.9"
             },
-            "time": "2020-08-15T07:42:40+00:00"
+            "time": "2021-10-12T10:49:25+00:00"
         },
         {
             "name": "sentry/sentry",
@@ -2496,34 +2537,35 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.2.0",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "fa1219ecbf96bb5db59f2599cba0960a0d9c3aea"
+                "reference": "2e082dae50da563c639119b7b52347a2a3db4ba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/fa1219ecbf96bb5db59f2599cba0960a0d9c3aea",
-                "reference": "fa1219ecbf96bb5db59f2599cba0960a0d9c3aea",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2e082dae50da563c639119b7b52347a2a3db4ba5",
+                "reference": "2e082dae50da563c639119b7b52347a2a3db4ba5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
-                "symfony/filesystem": "^4.4|^5.0",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/filesystem": "^4.4|^5.0|^6.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/polyfill-php81": "^1.22"
             },
             "conflict": {
                 "symfony/finder": "<4.4"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/finder": "^4.4|^5.0",
-                "symfony/messenger": "^4.4|^5.0",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/yaml": "^4.4|^5.0"
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/finder": "^4.4|^5.0|^6.0",
+                "symfony/messenger": "^4.4|^5.0|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/yaml": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -2551,10 +2593,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Config Component",
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.2.0"
+                "source": "https://github.com/symfony/config/tree/v5.4.2"
             },
             "funding": [
                 {
@@ -2570,30 +2612,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-16T18:02:40+00:00"
+            "time": "2021-12-15T11:06:13+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.7",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a"
+                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8b1008344647462ae6ec57559da166c2bfa5e16a",
-                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a2c6b7ced2eb7799a35375fb9022519282b5405e",
+                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php73": "^1.9",
                 "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
                 "psr/log": ">=3",
@@ -2608,12 +2650,12 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -2653,7 +2695,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.7"
+                "source": "https://github.com/symfony/console/tree/v5.4.2"
             },
             "funding": [
                 {
@@ -2669,7 +2711,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-25T20:02:16+00:00"
+            "time": "2021-12-20T16:11:12+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -2738,16 +2780,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
                 "shasum": ""
             },
             "require": {
@@ -2756,7 +2798,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2785,7 +2827,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -2801,7 +2843,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "time": "2021-07-12T14:48:14+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -2879,21 +2921,22 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.3.4",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32"
+                "reference": "731f917dc31edcffec2c6a777f3698c33bea8f01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/343f4fe324383ca46792cae728a3b6e2f708fb32",
-                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/731f917dc31edcffec2c6a777f3698c33bea8f01",
+                "reference": "731f917dc31edcffec2c6a777f3698c33bea8f01",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8",
                 "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
@@ -2922,7 +2965,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.3.4"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.0"
             },
             "funding": [
                 {
@@ -2938,7 +2981,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-21T12:40:44+00:00"
+            "time": "2021-10-28T13:39:27+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -3029,16 +3072,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "7e82f6084d7cae521a75ef2cb5c9457bbda785f4"
+                "reference": "ec82e57b5b714dbb69300d348bd840b345e24166"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/7e82f6084d7cae521a75ef2cb5c9457bbda785f4",
-                "reference": "7e82f6084d7cae521a75ef2cb5c9457bbda785f4",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/ec82e57b5b714dbb69300d348bd840b345e24166",
+                "reference": "ec82e57b5b714dbb69300d348bd840b345e24166",
                 "shasum": ""
             },
             "require": {
@@ -3050,7 +3093,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3087,7 +3130,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -3103,7 +3146,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-11T23:07:08+00:00"
+            "time": "2021-11-03T09:24:47+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -3824,6 +3867,85 @@
             "time": "2021-07-28T13:41:28+00:00"
         },
         {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "e66119f3de95efc359483f810c4c3e6436279436"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/e66119f3de95efc359483f810c4c3e6436279436",
+                "reference": "e66119f3de95efc359483f810c4c3e6436279436",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-21T13:25:03+00:00"
+        },
+        {
             "name": "symfony/polyfill-uuid",
             "version": "v1.23.0",
             "source": {
@@ -3904,33 +4026,29 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.4.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1"
+                "php": "^7.1.3"
             },
             "suggest": {
+                "psr/container": "",
                 "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -3963,36 +4081,22 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v1.1.2"
             },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-04-01T10:43:52+00:00"
+            "time": "2019-05-28T07:50:59+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.3.7",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5"
+                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8d224396e28d30f81969f083a58763b8b9ceb0a5",
-                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
+                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
                 "shasum": ""
             },
             "require": {
@@ -4003,11 +4107,14 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "~1.15"
             },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4046,7 +4153,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.7"
+                "source": "https://github.com/symfony/string/tree/v5.4.2"
             },
             "funding": [
                 {
@@ -4062,7 +4169,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-26T08:00:08+00:00"
+            "time": "2021-12-16T21:52:00+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -7522,5 +7629,5 @@
         "php": ">=7.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/Migrations/20171229051919_AddNameWithRankIdToTitleScoreDetails.php
+++ b/config/Migrations/20171229051919_AddNameWithRankIdToTitleScoreDetails.php
@@ -1,4 +1,5 @@
 <?php
+
 // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\TableRegistry;
@@ -14,6 +15,7 @@ class AddNameWithRankIdToTitleScoreDetails extends AbstractMigration
      *
      * More information on this method is available here:
      * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change()
@@ -51,7 +53,7 @@ class AddNameWithRankIdToTitleScoreDetails extends AbstractMigration
                 'id',
                 [
                     'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT'
+                    'delete' => 'RESTRICT',
                 ]
             )
             ->update();

--- a/config/routes.php
+++ b/config/routes.php
@@ -22,179 +22,180 @@
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Router;
 
-/**
- * The default class to use for all routes
- *
- * The following route classes are supplied with CakePHP and are appropriate
- * to set as the default:
- *
- * - Route
- * - InflectedRoute
- * - DashedRoute
- *
- * If no call is made to `Router::defaultRouteClass()`, the class used is
- * `Route` (`Cake\Routing\Route\Route`)
- *
- * Note that `Route` does not do any inflections on URLs which will result in
- * inconsistently cased URLs when used with `:plugin`, `:controller` and
- * `:action` markers.
- */
-Router::defaultRouteClass(DashedRoute::class);
-
-Router::scope('/', function (RouteBuilder $routes) {
-    // Register scoped middleware for in scopes.
-    $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([
-        'httpOnly' => true,
-    ]));
-
+return static function (RouteBuilder $routes) {
     /**
-     * Apply a middleware to the current route scope.
-     * Requires middleware to be registered via `Application::routes()` with `registerMiddleware()`
+     * The default class to use for all routes
+     *
+     * The following route classes are supplied with CakePHP and are appropriate
+     * to set as the default:
+     *
+     * - Route
+     * - InflectedRoute
+     * - DashedRoute
+     *
+     * If no call is made to `Router::defaultRouteClass()`, the class used is
+     * `Route` (`Cake\Routing\Route\Route`)
+     *
+     * Note that `Route` does not do any inflections on URLs which will result in
+     * inconsistently cased URLs when used with `{plugin}`, `{controller}` and
+     * `{action}` markers.
      */
-    $routes->applyMiddleware('csrf');
+    $routes->setRouteClass(DashedRoute::class);
 
-    $routes->scope('/', ['controller' => 'Users'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'top');
-        $routes->post('/login', ['action' => 'login'], 'login');
-        $routes->get('/logout', ['action' => 'logout'], 'logout');
-    });
+    $routes->scope('/', function (RouteBuilder $routes) {
+        // Register scoped middleware for in scopes.
+        $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([
+            'httponly' => true,
+        ]));
 
-    $routes->scope('/players', ['controller' => 'Players'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'players');
-        $routes->get('/search', ['action' => 'search'], 'find_players');
-        $routes->get('/new', ['action' => 'new'], 'new_player');
-        $routes->post('/new', ['action' => 'create'], 'create_player');
-        $routes->get('/:id', ['action' => 'view'], 'view_player')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->put('/:id', ['action' => 'update'], 'update_player')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        /**
+         * Apply a middleware to the current route scope.
+         * Requires middleware to be registered via `Application::routes()` with `registerMiddleware()`
+         */
+        $routes->applyMiddleware('csrf');
 
-        $routes->get('/ranking', ['action' => 'ranking'], 'ranking');
-    });
+        $routes->scope('/', ['controller' => 'Users'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'top');
+            $routes->post('/login', ['action' => 'login'], 'login');
+            $routes->get('/logout', ['action' => 'logout'], 'logout');
+        });
 
-    $routes->scope('/players', function (RouteBuilder $routes) {
-        $routes->get(
-            '/:id/scores/:year',
-            ['controller' => 'TitleScores', 'action' => 'searchByPlayer'],
-            'find_player_scores'
-        )->setPatterns([
-            'id' => RouteBuilder::ID, 'year' => RouteBuilder::ID,
-        ])->setPass(['id', 'year']);
-        $routes->post(
-            '/:id/ranks',
-            ['controller' => 'PlayerRanks', 'action' => 'create'],
-            'create_ranks'
-        )->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->put(
-            '/:id/ranks/:rowId',
-            ['controller' => 'PlayerRanks', 'action' => 'update'],
-            'update_ranks'
-        )->setPatterns([
-            'id' => RouteBuilder::ID, 'rowId' => RouteBuilder::ID,
-        ])->setPass(['id', 'rowId']);
-    });
+        $routes->scope('/players', ['controller' => 'Players'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'players');
+            $routes->get('/search', ['action' => 'search'], 'find_players');
+            $routes->get('/new', ['action' => 'new'], 'new_player');
+            $routes->post('/new', ['action' => 'create'], 'create_player');
+            $routes->get('/{id}', ['action' => 'view'], 'view_player')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->put('/{id}', ['action' => 'update'], 'update_player')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
 
-    $routes->scope('/ranks', ['controller' => 'PlayerRanks'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'ranks');
-    });
+            $routes->get('/ranking', ['action' => 'ranking'], 'ranking');
+        });
 
-    // タイトル
-    $routes->scope('/titles', ['controller' => 'Titles'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'titles');
-        $routes->get('/:id', ['action' => 'view'], 'view_title')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->put('/:id', ['action' => 'update'], 'update_title')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        $routes->scope('/players', function (RouteBuilder $routes) {
+            $routes->get(
+                '/{id}/scores/{year}',
+                ['controller' => 'TitleScores', 'action' => 'searchByPlayer'],
+                'find_player_scores'
+            )->setPatterns([
+                'id' => RouteBuilder::ID, 'year' => RouteBuilder::ID,
+            ])->setPass(['id', 'year']);
+            $routes->post(
+                '/{id}/ranks',
+                ['controller' => 'PlayerRanks', 'action' => 'create'],
+                'create_ranks'
+            )->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->put(
+                '/{id}/ranks/{rowId}',
+                ['controller' => 'PlayerRanks', 'action' => 'update'],
+                'update_ranks'
+            )->setPatterns([
+                'id' => RouteBuilder::ID, 'rowId' => RouteBuilder::ID,
+            ])->setPass(['id', 'rowId']);
+        });
+
+        $routes->scope('/ranks', ['controller' => 'PlayerRanks'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'ranks');
+        });
 
         // タイトル
-        $routes->scope('/:id/histories', ['controller' => 'RetentionHistories'], function (RouteBuilder $routes) {
-            $routes->post('/', ['action' => 'save'], 'save_histories')
-                ->setPass(['id']);
+        $routes->scope('/titles', ['controller' => 'Titles'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'titles');
+            $routes->get('/{id}', ['action' => 'view'], 'view_title')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->put('/{id}', ['action' => 'update'], 'update_title')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+
+            // タイトル
+            $routes->scope('/{id}/histories', ['controller' => 'RetentionHistories'], function (RouteBuilder $routes) {
+                $routes->post('/', ['action' => 'save'], 'save_histories')
+                    ->setPass(['id']);
+            });
+        });
+
+        // タイトル成績
+        $routes->scope('/scores', ['controller' => 'TitleScores'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'scores');
+            $routes->get('/search', ['action' => 'search'], 'find_scores');
+            $routes->get('/{id}', ['action' => 'view'], 'view_score')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->put('/{id}', ['action' => 'update'], 'update_score')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->delete('/{id}', ['action' => 'delete'], 'delete_score')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        });
+
+        // クエリ実行
+        $routes->scope('/queries', ['controller' => 'NativeQuery'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'queries');
+            $routes->post('/', ['action' => 'execute'], 'execute_queries');
+        });
+
+        // お知らせ
+        $routes->scope('/notifications', ['controller' => 'Notifications'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'notifications');
+            $routes->get('/new', ['action' => 'new'], 'new_notification');
+            $routes->post('/', ['action' => 'create'], 'create_notification');
+            $routes->get('/{id}', ['action' => 'edit'], 'edit_notification')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->put('/{id}', ['action' => 'update'], 'update_notification')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->delete('/{id}', ['action' => 'delete'], 'delete_notification')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        });
+
+        // 表テンプレート
+        $routes->scope('/table-templates', ['controller' => 'TableTemplates'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'table_templates');
+            $routes->get('/new', ['action' => 'new'], 'new_table_template');
+            $routes->post('/', ['action' => 'create'], 'create_table_template');
+            $routes->get('/{id}', ['action' => 'edit'], 'edit_table_template')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->put('/{id}', ['action' => 'update'], 'update_table_template')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->delete('/{id}', ['action' => 'delete'], 'delete_table_template')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+        });
+
+        // フォールバックメソッド
+        // $routes->fallbacks(DashedRoute::class);
+    });
+
+    // api
+    $routes->prefix('api', function (RouteBuilder $routes) {
+        $routes->setExtensions(['json']);
+
+        $routes->get('/years', ['controller' => 'Years', 'action' => 'index'], 'api_years');
+
+        $routes->get('/countries', ['controller' => 'Countries', 'action' => 'index'], 'api_countries');
+
+        $routes->get('/ranks', ['controller' => 'Ranks', 'action' => 'index'], 'api_ranks');
+
+        $routes->scope('/players', ['controller' => 'Players'], function (RouteBuilder $routes) {
+            $routes->post('/', ['action' => 'search'], 'api_players');
+            $routes->get('/ranking/{country}/{year}/{limit}', ['controller' => 'Players', 'action' => 'searchRanking'], 'api_ranking')
+                ->setPatterns(['year' => RouteBuilder::ID, 'limit' => RouteBuilder::ID])
+                ->setPass(['country', 'year', 'limit']);
+            $routes->post('/ranking/{country}/{year}/{limit}', ['action' => 'createRanking'], 'api_create_ranking')
+                ->setPatterns(['year' => RouteBuilder::ID, 'limit' => RouteBuilder::ID])
+                ->setPass(['country', 'year', 'limit']);
+            $routes->get('/ranks/{country_id}', ['action' => 'searchRanks'], 'api_player_ranks')
+                ->setPatterns(['country_id' => RouteBuilder::ID])->setPass(['country_id']);
+        });
+
+        $routes->scope('/titles', ['controller' => 'Titles'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'api_titles');
+            $routes->post('/', ['action' => 'create'], 'api_create_titles');
+            $routes->put('//{id}', ['action' => 'update'], 'api_update_titles')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
+            $routes->post('/news', ['action' => 'createNews'], 'api_news');
+        });
+
+        $routes->scope('/histories', ['controller' => 'RetentionHistories'], function (RouteBuilder $routes) {
+            $routes->get('/{id}', ['action' => 'view'], 'api_history')
+                ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
         });
     });
-
-    // タイトル成績
-    $routes->scope('/scores', ['controller' => 'TitleScores'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'scores');
-        $routes->get('/search', ['action' => 'search'], 'find_scores');
-        $routes->get('/:id', ['action' => 'view'], 'view_score')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->put('/:id', ['action' => 'update'], 'update_score')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->delete('/:id', ['action' => 'delete'], 'delete_score')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-    });
-
-    // クエリ実行
-    $routes->scope('/queries', ['controller' => 'NativeQuery'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'queries');
-        $routes->post('/', ['action' => 'execute'], 'execute_queries');
-    });
-
-    // お知らせ
-    $routes->scope('/notifications', ['controller' => 'Notifications'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'notifications');
-        $routes->get('/new', ['action' => 'new'], 'new_notification');
-        $routes->post('/', ['action' => 'create'], 'create_notification');
-        $routes->get('/:id', ['action' => 'edit'], 'edit_notification')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->put('/:id', ['action' => 'update'], 'update_notification')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->delete('/:id', ['action' => 'delete'], 'delete_notification')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-    });
-
-    // 表テンプレート
-    $routes->scope('/table-templates', ['controller' => 'TableTemplates'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'table_templates');
-        $routes->get('/new', ['action' => 'new'], 'new_table_template');
-        $routes->post('/', ['action' => 'create'], 'create_table_template');
-        $routes->get('/:id', ['action' => 'edit'], 'edit_table_template')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->put('/:id', ['action' => 'update'], 'update_table_template')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->delete('/:id', ['action' => 'delete'], 'delete_table_template')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-    });
-
-    // フォールバックメソッド
-    // $routes->fallbacks(DashedRoute::class);
-});
-
-// api
-Router::prefix('api', function (RouteBuilder $routes) {
-    $routes->setExtensions(['json']);
-
-    $routes->get('/years', ['controller' => 'Years', 'action' => 'index'], 'api_years');
-
-    $routes->get('/countries', ['controller' => 'Countries', 'action' => 'index'], 'api_countries');
-
-    $routes->get('/ranks', ['controller' => 'Ranks', 'action' => 'index'], 'api_ranks');
-
-    $routes->scope('/players', ['controller' => 'Players'], function (RouteBuilder $routes) {
-        $routes->post('/', ['action' => 'search'], 'api_players');
-        $routes->get('/ranking/:country/:year/:offset', ['controller' => 'Players', 'action' => 'searchRanking'], 'api_ranking')
-            ->setPatterns(['year' => RouteBuilder::ID, 'offset' => RouteBuilder::ID])
-            ->setPass(['country', 'year', 'offset']);
-        $routes->post('/ranking/:country/:year/:offset', ['action' => 'createRanking'], 'api_create_ranking')
-            ->setPatterns(['year' => RouteBuilder::ID, 'offset' => RouteBuilder::ID])
-            ->setPass(['country', 'year', 'offset']);
-        $routes->get('/ranks/:country_id', ['action' => 'searchRanks'], 'api_player_ranks')
-            ->setPatterns(['country_id' => RouteBuilder::ID])->setPass(['country_id']);
-    });
-
-    $routes->scope('/titles', ['controller' => 'Titles'], function (RouteBuilder $routes) {
-        $routes->get('/', ['action' => 'index'], 'api_titles');
-        $routes->post('/', ['action' => 'create'], 'api_create_titles');
-        $routes->put('//:id', ['action' => 'update'], 'api_update_titles')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-        $routes->post('/news', ['action' => 'createNews'], 'api_news');
-    });
-
-    $routes->scope('/histories', ['controller' => 'RetentionHistories'], function (RouteBuilder $routes) {
-        $routes->get('/:id', ['action' => 'view'], 'api_history')
-            ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
-    });
-});
+};

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Gotea">
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
+
+    <rule ref="CakePHP"/>
+</ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<phpunit colors="true" processIsolation="false" stopOnFailure="false" bootstrap="./tests/bootstrap.php">
+<phpunit
+  colors="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  bootstrap="tests/bootstrap.php"
+>
   <php>
     <ini name="memory_limit" value="-1" />
     <ini name="apc.enable_cli" value="1" />
@@ -8,19 +13,15 @@
   <!-- Add any additional test suites you want to run here -->
   <testsuites>
     <testsuite name="App Test Suite">
-      <directory>./tests/TestCase</directory>
+      <directory>./tests/TestCase/</directory>
     </testsuite>
     <!-- Add plugin test suites here. -->
   </testsuites>
 
-  <!-- Setup a listener for fixtures -->
-  <listeners>
-    <listener class="\Cake\TestSuite\Fixture\FixtureInjector">
-      <arguments>
-        <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-      </arguments>
-    </listener>
-  </listeners>
+  <!-- Load extension for fixtures -->
+  <extensions>
+      <extension class="Cake\TestSuite\Fixture\PHPUnitExtension"/>
+  </extensions>
 
   <!-- Ignore vendor tests in code coverage reports -->
   <filter>

--- a/src/Command/PlayerRankCommand.php
+++ b/src/Command/PlayerRankCommand.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Gotea\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Log\Log;
@@ -32,10 +32,10 @@ class PlayerRankCommand extends Command
     public function initialize(): void
     {
         parent::initialize();
-        $this->loadModel('Players');
-        $this->loadModel('PlayerRanks');
-        $this->loadModel('Countries');
-        $this->loadModel('Ranks');
+        $this->Players = $this->fetchTable('Players');
+        $this->PlayerRanks = $this->fetchTable('PlayerRanks');
+        $this->Countries = $this->fetchTable('Countries');
+        $this->Ranks = $this->fetchTable('Ranks');
     }
 
     /**

--- a/src/Command/RankDiffCommand.php
+++ b/src/Command/RankDiffCommand.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Gotea\Command;
 
 use Cake\Collection\Collection;
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Http\Client as HttpClient;
@@ -38,10 +38,10 @@ class RankDiffCommand extends Command
     public function initialize(): void
     {
         parent::initialize();
-        $this->loadModel('Players');
-        $this->loadModel('Countries');
-        $this->loadModel('Ranks');
-        $this->loadModel('Organizations');
+        $this->Players = $this->fetchTable('Players');
+        $this->Countries = $this->fetchTable('Countries');
+        $this->Ranks = $this->fetchTable('Ranks');
+        $this->Organizations = $this->fetchTable('Organizations');
     }
 
     /**

--- a/src/Controller/Api/PlayersController.php
+++ b/src/Controller/Api/PlayersController.php
@@ -7,7 +7,7 @@ use Cake\Core\Configure;
 use Cake\Filesystem\File;
 use Cake\Filesystem\Folder;
 use Cake\Http\Response;
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 
@@ -44,12 +44,12 @@ class PlayersController extends ApiController
     /**
      * 所属国に該当する段位と棋士数を取得します。
      *
-     * @param string $countryId 所属国ID
+     * @param int $countryId 所属国ID
      * @return \Cake\Http\Response 段位別棋士一覧
      */
-    public function searchRanks(string $countryId): ?Response
+    public function searchRanks(int $countryId): ?Response
     {
-        $ranks = $this->Players->findRanksCount((int)$countryId);
+        $ranks = $this->Players->findRanksCount($countryId);
 
         return $this->renderJson($ranks);
     }
@@ -58,11 +58,11 @@ class PlayersController extends ApiController
      * ランキングを取得します。
      *
      * @param string $country 所属国
-     * @param string $year 対象年度
-     * @param string $limit 取得上限値
+     * @param int $year 対象年度
+     * @param int $limit 取得上限値
      * @return \Cake\Http\Response ランキング
      */
-    public function searchRanking(string $country, string $year, string $limit): ?Response
+    public function searchRanking(string $country, int $year, int $limit): ?Response
     {
         $request = $this->getRequest();
         $from = $request->getQuery('from');
@@ -71,8 +71,8 @@ class PlayersController extends ApiController
         // ランキングデータ取得
         $json = $this->getRankingData([
             'country' => $country,
-            'year' => (int)$year,
-            'limit' => (int)$limit,
+            'year' => $year,
+            'limit' => $limit,
             'from' => $from,
             'to' => $to,
             'ja' => true,
@@ -89,11 +89,11 @@ class PlayersController extends ApiController
      * ランキングJSONデータを生成します。
      *
      * @param string $country 所属国
-     * @param string $year 対象年度
-     * @param string $limit 取得上限値
+     * @param int $year 対象年度
+     * @param int $limit 取得上限値
      * @return \Cake\Http\Response ランキング
      */
-    public function createRanking(string $country, string $year, string $limit): ?Response
+    public function createRanking(string $country, int $year, int $limit): ?Response
     {
         $request = $this->getRequest();
         $from = $request->getData('from');
@@ -102,8 +102,8 @@ class PlayersController extends ApiController
         // ランキングデータ取得
         $json = $this->getRankingData([
             'country' => $country,
-            'year' => (int)$year,
-            'limit' => (int)$limit,
+            'year' => $year,
+            'limit' => $limit,
             'from' => $from,
             'to' => $to,
         ]);
@@ -116,7 +116,7 @@ class PlayersController extends ApiController
         $dir = $json['countryCode'];
         $folder = new Folder(Configure::read('App.jsonDir') . 'ranking' . DS . $dir, true, 0755);
         if ($folder->errors()) {
-            Log::error($folder->errors());
+            Log::error(implode(', ', $folder->errors()));
 
             return $this->renderError(500, 'JSON出力失敗');
         }
@@ -141,9 +141,9 @@ class PlayersController extends ApiController
      */
     private function getRankingData(array $params): array
     {
-        // モデルのロード
-        $this->loadModel('Countries');
-        $this->loadModel('TitleScoreDetails');
+        // テーブルクラスのロード
+        $this->Countries = $this->fetchTable('Countries');
+        $this->TitleScoreDetails = $this->fetchTable('TitleScoreDetails');
 
         // 集計対象国の取得
         $countryCode = Hash::get($params, 'country');
@@ -160,8 +160,8 @@ class PlayersController extends ApiController
         $withJa = Hash::get($params, 'ja', false);
 
         // 開始日・終了日の補填
-        $from = $from ? Date::parse($from) : Date::createFromDate($year, 1, 1);
-        $to = $to ? Date::parse($to) : Date::createFromDate($year, 12, 31);
+        $from = $from ? FrozenDate::parse($from) : FrozenDate::createFromDate($year, 1, 1);
+        $to = $to ? FrozenDate::parse($to) : FrozenDate::createFromDate($year, 12, 31);
 
         // ランキングデータの取得
         $ranking = $this->TitleScoreDetails

--- a/src/Controller/Api/RetentionHistoriesController.php
+++ b/src/Controller/Api/RetentionHistoriesController.php
@@ -13,10 +13,10 @@ class RetentionHistoriesController extends ApiController
     /**
      * 履歴を1件取得します。
      *
-     * @param string $id ID
+     * @param int $id ID
      * @return \Cake\Http\Response 所属国一覧
      */
-    public function view(string $id)
+    public function view(int $id)
     {
         /** @var \Gotea\Model\Entity\RetentionHistory $history */
         $history = $this->RetentionHistories->get($id, [

--- a/src/Controller/Api/TitlesController.php
+++ b/src/Controller/Api/TitlesController.php
@@ -49,12 +49,12 @@ class TitlesController extends ApiController
     /**
      * タイトルを更新します。
      *
-     * @param string $id ID
+     * @param int $id ID
      * @return \Cake\Http\Response|null
      */
-    public function update(string $id): ?Response
+    public function update(int $id): ?Response
     {
-        $title = $this->Titles->createEntity((int)$id, $this->getRequest()->getParsedBody());
+        $title = $this->Titles->createEntity($id, $this->getRequest()->getParsedBody());
 
         if (!$this->Titles->save($title)) {
             return $this->renderError(400, $title->getValidateErrors());

--- a/src/Controller/NotificationsController.php
+++ b/src/Controller/NotificationsController.php
@@ -73,11 +73,11 @@ class NotificationsController extends AppController
     /**
      * 編集画面表示処理
      *
-     * @param string $id サロゲートキー
+     * @param int $id サロゲートキー
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function edit(string $id): ?Response
+    public function edit(int $id): ?Response
     {
         $notification = $this->Notifications->get($id, [
             'contain' => [],
@@ -114,11 +114,11 @@ class NotificationsController extends AppController
     /**
      * 更新処理
      *
-     * @param string $id サロゲートキー
+     * @param int $id サロゲートキー
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function update(string $id): ?Response
+    public function update(int $id): ?Response
     {
         $notification = $this->Notifications->get($id);
         $isPublished = $notification->is_published;
@@ -141,11 +141,11 @@ class NotificationsController extends AppController
     /**
      * 削除処理
      *
-     * @param string $id サロゲートキー
+     * @param int $id サロゲートキー
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function delete(string $id): ?Response
+    public function delete(int $id): ?Response
     {
         $notification = $this->Notifications->get($id);
         if ($this->Notifications->delete($notification)) {

--- a/src/Controller/PlayerRanksController.php
+++ b/src/Controller/PlayerRanksController.php
@@ -38,10 +38,10 @@ class PlayerRanksController extends AppController
     /**
      * 登録処理
      *
-     * @param string $playerId 棋士ID
+     * @param int $playerId 棋士ID
      * @return \Cake\Http\Response|null
      */
-    public function create(string $playerId): ?Response
+    public function create(int $playerId): ?Response
     {
         $data = $this->getRequest()->withData('player_id', $playerId)->getParsedBody();
         $rank = $this->PlayerRanks->newEntity($data);
@@ -63,11 +63,11 @@ class PlayerRanksController extends AppController
     /**
      * 更新処理
      *
-     * @param string $playerId 棋士ID
-     * @param string $id 昇段情報ID
+     * @param int $playerId 棋士ID
+     * @param int $id 昇段情報ID
      * @return \Cake\Http\Response|null
      */
-    public function update(string $playerId, string $id): ?Response
+    public function update(int $playerId, int $id): ?Response
     {
         $data = $this->getRequest()->withData('player_id', $playerId)->getParsedBody();
         $rank = $this->PlayerRanks->get($id);

--- a/src/Controller/PlayersController.php
+++ b/src/Controller/PlayersController.php
@@ -27,10 +27,10 @@ class PlayersController extends AppController
     {
         parent::initialize();
 
-        $this->loadModel('Countries');
-        $this->loadModel('Ranks');
-        $this->loadModel('Organizations');
-        $this->loadModel('TitleScores');
+        $this->Countries = $this->fetchTable('Countries');
+        $this->Ranks = $this->fetchTable('Ranks');
+        $this->Organizations = $this->fetchTable('Organizations');
+        $this->TitleScores = $this->fetchTable('TitleScores');
 
         $this->loadComponent('Paginator');
     }
@@ -134,12 +134,12 @@ class PlayersController extends AppController
     /**
      * 詳細表示処理
      *
-     * @param string $id 取得するデータのID
+     * @param int $id 取得するデータのID
      * @return \Cake\Http\Response|null
      */
-    public function view(string $id): ?Response
+    public function view(int $id): ?Response
     {
-        $player = $this->Players->findByIdWithRelation((int)$id);
+        $player = $this->Players->findByIdWithRelation($id);
 
         return $this->set(compact('player'))->withRanks()->renderWithDialog();
     }
@@ -182,14 +182,14 @@ class PlayersController extends AppController
     /**
      * 棋士の更新処理
      *
-     * @param string $id 対象の棋士ID
+     * @param int $id 対象の棋士ID
      * @return \Cake\Http\Response|null
      */
-    public function update(string $id): ?Response
+    public function update(int $id): ?Response
     {
         // エンティティ取得
         $data = $this->getRequest()->getParsedBody();
-        $player = $this->Players->findByIdWithRelation((int)$id);
+        $player = $this->Players->findByIdWithRelation($id);
         $this->Players->patchEntity($player, $data);
 
         // 失敗

--- a/src/Controller/RetentionHistoriesController.php
+++ b/src/Controller/RetentionHistoriesController.php
@@ -27,10 +27,10 @@ class RetentionHistoriesController extends AppController
     /**
      * 登録・更新処理
      *
-     * @param string $id タイトルID
+     * @param int $id タイトルID
      * @return \Cake\Http\Response|null
      */
-    public function save(string $id)
+    public function save(int $id)
     {
         // エンティティ取得 or 生成
         $historyId = $this->getRequest()->getData('id', '');

--- a/src/Controller/TableTemplatesController.php
+++ b/src/Controller/TableTemplatesController.php
@@ -55,11 +55,11 @@ class TableTemplatesController extends AppController
     /**
      * 編集画面表示処理
      *
-     * @param string $id サロゲートキー
+     * @param int $id サロゲートキー
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function edit(string $id): ?Response
+    public function edit(int $id): ?Response
     {
         $tableTemplate = $this->TableTemplates->get($id, [
             'contain' => [],
@@ -92,11 +92,11 @@ class TableTemplatesController extends AppController
     /**
      * 更新処理
      *
-     * @param string $id サロゲートキー
+     * @param int $id サロゲートキー
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function update(string $id): ?Response
+    public function update(int $id): ?Response
     {
         $tableTemplate = $this->TableTemplates->get($id);
         $tableTemplate = $this->TableTemplates->patchEntity($tableTemplate, $this->getRequest()->getData());
@@ -114,11 +114,11 @@ class TableTemplatesController extends AppController
     /**
      * 削除処理
      *
-     * @param string $id サロゲートキー
+     * @param int $id サロゲートキー
      * @return \Cake\Http\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function delete(string $id): ?Response
+    public function delete(int $id): ?Response
     {
         $tableTemplate = $this->TableTemplates->get($id);
         if ($this->TableTemplates->delete($tableTemplate)) {

--- a/src/Controller/TitleScoresController.php
+++ b/src/Controller/TitleScoresController.php
@@ -34,9 +34,9 @@ class TitleScoresController extends AppController
     {
         parent::initialize();
 
-        $this->loadModel('Players');
-        $this->loadModel('Titles');
-        $this->loadModel('TitleScoreDetails');
+        $this->Players = $this->fetchTable('Players');
+        $this->Titles = $this->fetchTable('Titles');
+        $this->TitleScoreDetails = $this->fetchTable('TitleScoreDetails');
 
         $this->loadComponent('Paginator');
     }
@@ -85,14 +85,12 @@ class TitleScoresController extends AppController
     /**
      * 指定した棋士・年度に該当する成績の取得処理
      *
-     * @param string $id 棋士ID
-     * @param string $year 対象年度
+     * @param int $id 棋士ID
+     * @param int $year 対象年度
      * @return \Cake\Http\Response|null
      */
-    public function searchByPlayer(string $id, string $year): ?Response
+    public function searchByPlayer(int $id, int $year): ?Response
     {
-        $id = (int)$id;
-        $year = (int)$year;
         $player = $this->Players->get($id);
         $titleScores = $this->TitleScores->findMatches([
             'player_id' => $id,
@@ -107,12 +105,12 @@ class TitleScoresController extends AppController
     /**
      * 詳細表示処理
      *
-     * @param string $id 取得するデータのID
+     * @param int $id 取得するデータのID
      * @return \Cake\Http\Response|null
      */
-    public function view(string $id): ?Response
+    public function view(int $id): ?Response
     {
-        $score = $this->TitleScores->findByIdWithRelation((int)$id);
+        $score = $this->TitleScores->findByIdWithRelation($id);
         $activeTitles = $this->Titles->findSortedList();
 
         return $this->set(compact('score', 'activeTitles'))->renderWithDialog();
@@ -121,10 +119,10 @@ class TitleScoresController extends AppController
     /**
      * 更新処理
      *
-     * @param string $id 成績ID
+     * @param int $id 成績ID
      * @return \Cake\Http\Response|null
      */
-    public function update(string $id): ?Response
+    public function update(int $id): ?Response
     {
         // 勝敗変更の場合は該当アクションを実施
         if ($this->getRequest()->getData('action') == 'switchDivision') {
@@ -138,7 +136,7 @@ class TitleScoresController extends AppController
         }
 
         // データ取得
-        $score = $this->TitleScores->findByIdWithRelation((int)$id);
+        $score = $this->TitleScores->findByIdWithRelation($id);
         $this->TitleScores->patchEntity($score, $data);
 
         // 保存
@@ -160,10 +158,10 @@ class TitleScoresController extends AppController
     /**
      * 削除処理
      *
-     * @param string $id 成績ID
+     * @param int $id 成績ID
      * @return \Cake\Http\Response|null
      */
-    public function delete(string $id): ?Response
+    public function delete(int $id): ?Response
     {
         $model = $this->TitleScores->get($id, [
             'contain' => 'TitleScoreDetails',
@@ -185,10 +183,10 @@ class TitleScoresController extends AppController
     /**
      * 勝敗変更処理
      *
-     * @param string $id 成績ID
+     * @param int $id 成績ID
      * @return \Cake\Http\Response|null
      */
-    private function switchDivision(string $id): ?Response
+    private function switchDivision(int $id): ?Response
     {
         $score = $this->TitleScores->get($id, [
             'contain' => 'TitleScoreDetails',

--- a/src/Controller/TitlesController.php
+++ b/src/Controller/TitlesController.php
@@ -38,12 +38,12 @@ class TitlesController extends AppController
     /**
      * 詳細表示処理
      *
-     * @param string $id 取得するデータのID
+     * @param int $id 取得するデータのID
      * @return \Cake\Http\Response|null
      */
-    public function view(string $id): ?Response
+    public function view(int $id): ?Response
     {
-        $title = $this->Titles->findByIdWithRelation((int)$id);
+        $title = $this->Titles->findByIdWithRelation($id);
 
         return $this->set(compact('title'))->renderWithDialog();
     }
@@ -51,13 +51,13 @@ class TitlesController extends AppController
     /**
      * 更新処理
      *
-     * @param string $id タイトルID
+     * @param int $id タイトルID
      * @return \Cake\Http\Response|null
      */
-    public function update(string $id): ?Response
+    public function update(int $id): ?Response
     {
         // データ取得
-        $title = $this->Titles->findByIdWithRelation((int)$id);
+        $title = $this->Titles->findByIdWithRelation($id);
         $this->Titles->patchEntity($title, $this->getRequest()->getParsedBody());
 
         // 保存

--- a/src/Form/PlayerForm.php
+++ b/src/Form/PlayerForm.php
@@ -37,10 +37,16 @@ class PlayerForm extends AppForm
     public function buildValidator(Event $event, Validator $validator, $name): void
     {
         $validator
-            ->allowEmpty([
-                'country_id', 'organization_id', 'rank_id', 'is_retired', 'sex',
-                'name', 'name_english', 'name_other', 'joined_from', 'joined_to',
-            ])
+            ->allowEmptyString('country_id')
+            ->allowEmptyString('organization_id')
+            ->allowEmptyString('rank_id')
+            ->allowEmptyString('is_retired')
+            ->allowEmptyString('sex')
+            ->allowEmptyString('name')
+            ->allowEmptyString('name_english')
+            ->allowEmptyString('name_other')
+            ->allowEmptyString('joined_from')
+            ->allowEmptyString('joined_to')
             ->integer('country_id')
             ->integer('rank_id')
             ->integer('organization_id')

--- a/src/Form/TitleScoreForm.php
+++ b/src/Form/TitleScoreForm.php
@@ -33,12 +33,17 @@ class TitleScoreForm extends AppForm
     public function buildValidator(Event $event, Validator $validator, $name): void
     {
         $validator
-            ->allowEmpty(['name', 'title_name', 'country_id', 'target_year', 'started', 'ended'])
+            ->allowEmptyString('name')
+            ->allowEmptyString('title_name')
+            ->allowEmptyString('country_id')
+            ->allowEmptyString('target_year')
+            ->allowEmptyDate('started')
+            ->allowEmptyDate('ended')
             ->integer('country_id')
             ->range('target_year', [1, 9999])
             ->maxLength('name', 20)
             ->maxLength('title_name', 20)
-            ->date('started', 'y/m/d')
-            ->date('ended', 'y/m/d');
+            ->date('started', ['y/m/d'])
+            ->date('ended', ['y/m/d']);
     }
 }

--- a/src/Middleware/TransactionMiddleware.php
+++ b/src/Middleware/TransactionMiddleware.php
@@ -39,6 +39,7 @@ class TransactionMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        /** @var \Cake\Database\Connection $conn */
         $conn = ConnectionManager::get($this->name);
 
         return $conn->enableSavePoints(true)

--- a/src/Model/Entity/PlayerRank.php
+++ b/src/Model/Entity/PlayerRank.php
@@ -9,9 +9,9 @@ namespace Gotea\Model\Entity;
  * @property int $id
  * @property int $player_id
  * @property int $rank_id
- * @property \Cake\I18n\Date $promoted
- * @property \Cake\I18n\Time $created
- * @property \Cake\I18n\Time $modified
+ * @property \Cake\I18n\FrozenDate $promoted
+ * @property \Cake\I18n\FrozenTime $created
+ * @property \Cake\I18n\FrozenTime $modified
  *
  * @property \Gotea\Model\Entity\Player $player
  * @property \Gotea\Model\Entity\Rank $rank

--- a/src/Model/Entity/TitleScore.php
+++ b/src/Model/Entity/TitleScore.php
@@ -170,10 +170,10 @@ class TitleScore extends AppEntity
      * 指定した棋士に合致するかを判定します。
      *
      * @param \Gotea\Model\Entity\Player|null $player 棋士
-     * @param string|null $id 棋士ID
+     * @param int|null $id 棋士ID
      * @return bool
      */
-    public function isSelected($player, $id = null)
+    public function isSelected($player, ?int $id)
     {
         if (!$player || !$id) {
             return false;

--- a/src/Model/Entity/TitleScoreDetail.php
+++ b/src/Model/Entity/TitleScoreDetail.php
@@ -13,8 +13,8 @@ use Cake\I18n\FrozenDate;
  * @property int $player_id
  * @property string $player_name
  * @property string $division
- * @property \Cake\I18n\Time $created
- * @property \Cake\I18n\Time $modified
+ * @property \Cake\I18n\FrozenTime $created
+ * @property \Cake\I18n\FrozenTime $modified
  *
  * @property \Gotea\Model\Entity\TitleScore $title_score
  * @property \Gotea\Model\Entity\Player $player

--- a/src/Model/Table/NotificationsTable.php
+++ b/src/Model/Table/NotificationsTable.php
@@ -48,31 +48,31 @@ class NotificationsTable extends AppTable
     {
         $validator
             ->nonNegativeInteger('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('title')
             ->maxLength('title', 100)
             ->requirePresence('title')
-            ->notEmpty('title');
+            ->notEmptyString('title');
 
         $validator
             ->scalar('content')
             ->requirePresence('content')
-            ->notEmpty('content');
+            ->notEmptyString('content');
 
         $validator
             ->boolean('is_draft')
-            ->notEmpty('is_draft');
+            ->notEmptyString('is_draft');
 
         $validator
             ->dateTime('published')
             ->requirePresence('published')
-            ->notEmpty('published');
+            ->notEmptyDateTime('published');
 
         $validator
             ->boolean('is_permanent')
-            ->notEmpty('is_permanent');
+            ->notEmptyString('is_permanent');
 
         return $validator;
     }

--- a/src/Model/Table/OrganizationsTable.php
+++ b/src/Model/Table/OrganizationsTable.php
@@ -28,7 +28,7 @@ class OrganizationsTable extends AppTable
      */
     public function validationDefault(Validator $validator): Validator
     {
-        return $validator->notEmpty('name', '組織名は必須です。');
+        return $validator->notEmptyString('name', '組織名は必須です。');
     }
 
     /**

--- a/src/Model/Table/PlayerRanksTable.php
+++ b/src/Model/Table/PlayerRanksTable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Gotea\Model\Table;
 
 use Cake\Datasource\EntityInterface;
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
@@ -50,13 +50,13 @@ class PlayerRanksTable extends AppTable
     {
         $validator
             ->integer('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->requirePresence(['player_id', 'rank_id', 'promoted'])
             ->integer('player_id')
             ->integer('rank_id')
-            ->date('promoted', 'y/m/d');
+            ->date('promoted', ['y/m/d']);
 
         return $validator;
     }
@@ -122,7 +122,7 @@ class PlayerRanksTable extends AppTable
                     return $q->where(['rank_numeric >' => 1]);
                 },
             ])
-            ->where(['PlayerRanks.promoted >=' => Date::now()->addMonths(-2)])
+            ->where(['PlayerRanks.promoted >=' => FrozenDate::now()->addMonths(-2)])
             ->orderDesc('PlayerRanks.promoted')
             ->order('Players.country_id')
             ->orderDesc('Ranks.rank_numeric');

--- a/src/Model/Table/PlayersTable.php
+++ b/src/Model/Table/PlayersTable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Gotea\Model\Table;
 
 use Cake\Datasource\EntityInterface;
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
@@ -108,7 +108,7 @@ class PlayersTable extends AppTable
         // 新規作成時には昇段情報も登録
         if ($save && $new) {
             // 入段日を登録時段位の昇段日として設定
-            $promoted = Date::parseDate($entity->joined, 'yyyyMMdd');
+            $promoted = FrozenDate::parseDate($entity->joined, 'yyyyMMdd');
 
             // 入段日が完全な日付だった場合、棋士昇段情報へ登録
             if ($promoted !== null) {

--- a/src/Model/Table/TitleScoreDetailsTable.php
+++ b/src/Model/Table/TitleScoreDetailsTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Model\Table;
 
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
@@ -45,7 +45,7 @@ class TitleScoreDetailsTable extends AppTable
     {
         $validator
             ->integer('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->requirePresence([
@@ -127,14 +127,15 @@ class TitleScoreDetailsTable extends AppTable
      *
      * @param \Gotea\Model\Entity\Country $country 所属国
      * @param int $limit 取得順位の上限
-     * @param \Cake\I18n\Date $started 対局日FROM
-     * @param \Cake\I18n\Date $ended 対局日TO
+     * @param \Cake\I18n\FrozenDate $started 対局日FROM
+     * @param \Cake\I18n\FrozenDate $ended 対局日TO
      * @return \Cake\ORM\Query 生成されたクエリ
      */
-    public function findRanking(Country $country, int $limit, Date $started, Date $ended)
+    public function findRanking(Country $country, int $limit, FrozenDate $started, FrozenDate $ended)
     {
         // 旧方式
         if ($this->isOldRanking($started->year)) {
+            /** @var \Gotea\Model\Table\PlayerScoresTable $playerScores */
             $playerScores = TableRegistry::getTableLocator()->get('PlayerScores');
 
             return $playerScores->findRanking($country, $started->year, $limit);
@@ -192,14 +193,15 @@ class TitleScoreDetailsTable extends AppTable
      * 最新データの対局日を取得します。
      *
      * @param \Gotea\Model\Entity\Country $country 所属国
-     * @param \Cake\I18n\Date $started 対局日FROM
-     * @param \Cake\I18n\Date $ended 対局日TO
+     * @param \Cake\I18n\FrozenDate $started 対局日FROM
+     * @param \Cake\I18n\FrozenDate $ended 対局日TO
      * @return string|null
      */
-    public function findRecent(Country $country, Date $started, Date $ended)
+    public function findRecent(Country $country, FrozenDate $started, FrozenDate $ended)
     {
         // 旧方式
         if ($this->isOldRanking($started->year)) {
+            /** @var \Gotea\Model\Table\UpdatedPointsTable $points */
             $points = TableRegistry::getTableLocator()->get('UpdatedPoints');
 
             return $points->findRecent($country, $started->year);
@@ -218,7 +220,7 @@ class TitleScoreDetailsTable extends AppTable
         }
 
         return $query->select([
-            'max' => $query->func()->max('ended'),
+            'max' => $query->func()->max('ended', ['text']),
         ], true)->first()->max;
     }
 

--- a/src/Model/Table/UpdatedPointsTable.php
+++ b/src/Model/Table/UpdatedPointsTable.php
@@ -28,6 +28,6 @@ class UpdatedPointsTable extends AppTable
             return '';
         }
 
-        return $target->score_updated->format('Y-m-d');
+        return $target->score_updated->i18nFormat('yyyy-MM-dd');
     }
 }

--- a/src/View/Cell/CountriesCell.php
+++ b/src/View/Cell/CountriesCell.php
@@ -7,8 +7,6 @@ use Cake\View\Cell;
 
 /**
  * 所属国を表示するためのセル
- *
- * @property \Gotea\Model\Table\CountriesTable $Countries
  */
 class CountriesCell extends Cell
 {
@@ -21,8 +19,9 @@ class CountriesCell extends Cell
      */
     public function display($hasTitleOnly = true, $attributes = [])
     {
-        $this->loadModel('Countries');
-        $countries = $this->Countries->findAllHasCode($hasTitleOnly)
+        /** @var \Gotea\Model\Table\CountriesTable $table */
+        $table = $this->fetchTable('Countries');
+        $countries = $table->findAllHasCode($hasTitleOnly)
             ->combine('id', 'name');
         $this->set(compact('countries', 'attributes'));
     }

--- a/src/View/Cell/NavigationCell.php
+++ b/src/View/Cell/NavigationCell.php
@@ -7,8 +7,6 @@ use Cake\View\Cell;
 
 /**
  * ナビゲーションに表示する情報
- *
- * @property \Gotea\Model\Table\PlayerRanksTable $PlayerRanks
  */
 class NavigationCell extends Cell
 {
@@ -27,8 +25,9 @@ class NavigationCell extends Cell
      */
     public function display()
     {
-        $this->loadModel('PlayerRanks');
-        $recents = $this->PlayerRanks
+        /** @var \Gotea\Model\Table\PlayerRanksTable $table */
+        $table = $this->fetchTable('PlayerRanks');
+        $recents = $table
             ->findRecentPromoted()
             ->reject(function ($item) {
                 // 入段日と昇段日が同じ（＝入段時点の段位の）場合は除外

--- a/src/View/Cell/OrganizationsCell.php
+++ b/src/View/Cell/OrganizationsCell.php
@@ -7,8 +7,6 @@ use Cake\View\Cell;
 
 /**
  * 所属組織を表示するためのセル
- *
- * @property \Gotea\Model\Table\OrganizationsTable $Organizations
  */
 class OrganizationsCell extends Cell
 {
@@ -20,8 +18,9 @@ class OrganizationsCell extends Cell
      */
     public function display($attributes = [])
     {
-        $this->loadModel('Organizations');
-        $organizations = $this->Organizations->findSorted();
+        /** @var \Gotea\Model\Table\OrganizationsTable $table */
+        $table = $this->fetchTable('Organizations');
+        $organizations = $table->findSorted();
         $this->set(compact('organizations', 'attributes'));
     }
 }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -27,7 +27,7 @@ class FormHelper extends BaseFormHelper
             'date' => '{{year}}{{month}}{{day}}',
             'datetime' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}',
             // エラーメッセージは個別に出力しない
-            'error' => false,
+            'error' => '',
         ]);
         $this->addWidget('date', ['Gotea.DateTime', 'select']);
         $this->addWidget('datetime', ['Gotea.DateTime', 'select']);

--- a/templates/Users/index.php
+++ b/templates/Users/index.php
@@ -1,28 +1,30 @@
+<?php
+/**
+ * @var \Gotea\View\AppView $this
+ * @var \Gotea\Form\LoginForm $form
+ */
+?>
 <?= $this->Form->create($form, [
     'method' => 'post',
     'url' => ['_name' => 'login'],
 ]) ?>
 <div class="login-row">
-    <?=
-        $this->Form->control('account', [
-            'label' => [
-                'class' => 'login-label',
-                'text' => 'ID',
-            ],
-            'class' => 'login-account',
-        ]);
-    ?>
+    <?= $this->Form->control('account', [
+        'label' => [
+            'class' => 'login-label',
+            'text' => 'ID',
+        ],
+        'class' => 'login-account',
+    ]); ?>
 </div>
 <div class="login-row">
-    <?=
-        $this->Form->control('password', [
-            'label' => [
-                'class' => 'login-label',
-                'text' => 'Password',
-            ],
-            'class' => 'login-password',
-        ]);
-    ?>
+    <?= $this->Form->control('password', [
+        'label' => [
+            'class' => 'login-label',
+            'text' => 'Password',
+        ],
+        'class' => 'login-password',
+    ]); ?>
 </div>
 <div class="row button-row">
     <?= $this->Form->hidden('redirect', ['value' => $this->getRequest()->getQuery('redirect')]) ?>

--- a/tests/Fixture/CountriesFixture.php
+++ b/tests/Fixture/CountriesFixture.php
@@ -10,32 +10,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class CountriesFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'code' => ['type' => 'string', 'length' => 2, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '国名コード（ラテン文字2文字）', 'precision' => null, 'fixed' => null],
-        'name' => ['type' => 'string', 'length' => 20, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '国名', 'precision' => null, 'fixed' => null],
-        'name_english' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '国名（英語）', 'precision' => null, 'fixed' => null],
-        'has_title' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '所属棋士有無', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_name' => ['type' => 'unique', 'columns' => ['name'], 'length' => []],
-            'uq_name_english' => ['type' => 'unique', 'columns' => ['name_english'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * @inheritDoc
      */
     public function init(): void

--- a/tests/Fixture/NotificationsFixture.php
+++ b/tests/Fixture/NotificationsFixture.php
@@ -9,31 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class NotificationsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'title' => ['type' => 'string', 'length' => 100, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル', 'precision' => null, 'fixed' => null],
-        'content' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '本文', 'precision' => null],
-        'is_draft' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '下書き', 'precision' => null],
-        'published' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '公開日時', 'precision' => null],
-        'is_permanent' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '恒久表示フラグ', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Init method
      *
      * @return void

--- a/tests/Fixture/OrganizationsFixture.php
+++ b/tests/Fixture/OrganizationsFixture.php
@@ -10,33 +10,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class OrganizationsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '国ID', 'precision' => null, 'autoIncrement' => null],
-        'name' => ['type' => 'string', 'length' => 20, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '組織名', 'precision' => null, 'fixed' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_indexes' => [
-            'fk_organization_to_country' => ['type' => 'index', 'columns' => ['country_id'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_name' => ['type' => 'unique', 'columns' => ['name'], 'length' => []],
-            'fk_organization_to_country' => ['type' => 'foreign', 'columns' => ['country_id'], 'references' => ['countries', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * @inheritDoc
      */
     public function init(): void

--- a/tests/Fixture/PlayerRanksFixture.php
+++ b/tests/Fixture/PlayerRanksFixture.php
@@ -1,7 +1,7 @@
 <?php
 namespace Gotea\Test\Fixture;
 
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
@@ -9,35 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class PlayerRanksFixture extends TestFixture
 {
-    /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'player_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '棋士ID', 'precision' => null, 'autoIncrement' => null],
-        'rank_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '段位ID', 'precision' => null, 'autoIncrement' => null],
-        'promoted' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '昇段日', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_indexes' => [
-            'player_id' => ['type' => 'index', 'columns' => ['player_id'], 'length' => []],
-            'rank_id' => ['type' => 'index', 'columns' => ['rank_id'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'player_ranks_ibfk_1' => ['type' => 'foreign', 'columns' => ['player_id'], 'references' => ['players', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'player_ranks_ibfk_2' => ['type' => 'foreign', 'columns' => ['rank_id'], 'references' => ['ranks', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
     /**
      * Records
      *
@@ -60,7 +31,7 @@ class PlayerRanksFixture extends TestFixture
     public function init(): void
     {
         // 最近の昇段情報
-        $now = Date::now();
+        $now = FrozenDate::now();
         $this->records[] = [
             'player_id' => 1,
             'rank_id' => 2,

--- a/tests/Fixture/PlayerScoresFixture.php
+++ b/tests/Fixture/PlayerScoresFixture.php
@@ -9,43 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class PlayerScoresFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'player_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '棋士ID', 'precision' => null, 'autoIncrement' => null],
-        'rank_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '段位ID', 'precision' => null, 'autoIncrement' => null],
-        'target_year' => ['type' => 'integer', 'length' => 4, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '対象年', 'precision' => null, 'autoIncrement' => null],
-        'win_point' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => '0', 'comment' => '勝数', 'precision' => null, 'autoIncrement' => null],
-        'lose_point' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => '0', 'comment' => '敗数', 'precision' => null, 'autoIncrement' => null],
-        'draw_point' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => '0', 'comment' => '引分数', 'precision' => null, 'autoIncrement' => null],
-        'win_point_world' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => '0', 'comment' => '勝数（国際棋戦）', 'precision' => null, 'autoIncrement' => null],
-        'lose_point_world' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => '0', 'comment' => '敗数（国際棋戦）', 'precision' => null, 'autoIncrement' => null],
-        'draw_point_world' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => '0', 'comment' => '引分数（国際棋戦）', 'precision' => null, 'autoIncrement' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        'modified_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '最終更新者', 'precision' => null, 'fixed' => null],
-        '_indexes' => [
-            'fk_scores_to_rank' => ['type' => 'index', 'columns' => ['rank_id'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_player_scores' => ['type' => 'unique', 'columns' => ['player_id', 'target_year'], 'length' => []],
-            'fk_scores_to_player' => ['type' => 'foreign', 'columns' => ['player_id'], 'references' => ['players', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'fk_scores_to_rank' => ['type' => 'foreign', 'columns' => ['rank_id'], 'references' => ['ranks', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/PlayersFixture.php
+++ b/tests/Fixture/PlayersFixture.php
@@ -9,49 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class PlayersFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '所属国ID', 'precision' => null, 'autoIncrement' => null],
-        'rank_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '段位ID', 'precision' => null, 'autoIncrement' => null],
-        'organization_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '所属ID', 'precision' => null, 'autoIncrement' => null],
-        'name' => ['type' => 'string', 'length' => 20, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '棋士名', 'precision' => null, 'fixed' => null],
-        'name_english' => ['type' => 'string', 'length' => 40, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '棋士名（英語）', 'precision' => null, 'fixed' => null],
-        'name_other' => ['type' => 'string', 'length' => 20, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '棋士名（その他）', 'precision' => null, 'fixed' => null],
-        'sex' => ['type' => 'string', 'length' => 2, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '性別', 'precision' => null, 'fixed' => null],
-        'joined' => ['type' => 'string', 'length' => 8, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '入段日', 'precision' => null, 'fixed' => null],
-        'birthday' => ['type' => 'date', 'length' => null, 'null' => true, 'default' => null, 'comment' => '生年月日', 'precision' => null],
-        'remarks' => ['type' => 'string', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'その他備考', 'precision' => null, 'fixed' => null],
-        'is_retired' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '引退済', 'precision' => null],
-        'retired' => ['type' => 'date', 'length' => null, 'null' => true, 'default' => null, 'comment' => '引退日', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        'modified_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '最終更新者', 'precision' => null, 'fixed' => null],
-        '_indexes' => [
-            'idx_name' => ['type' => 'index', 'columns' => ['name'], 'length' => []],
-            'fk_player_to_rank' => ['type' => 'index', 'columns' => ['rank_id'], 'length' => []],
-            'fk_player_to_organization' => ['type' => 'index', 'columns' => ['organization_id'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_player' => ['type' => 'unique', 'columns' => ['country_id', 'name', 'birthday'], 'length' => []],
-            'fk_player_to_country' => ['type' => 'foreign', 'columns' => ['country_id'], 'references' => ['countries', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'fk_player_to_organization' => ['type' => 'foreign', 'columns' => ['organization_id'], 'references' => ['organizations', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'fk_player_to_rank' => ['type' => 'foreign', 'columns' => ['rank_id'], 'references' => ['ranks', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/RanksFixture.php
+++ b/tests/Fixture/RanksFixture.php
@@ -10,29 +10,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class RanksFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '段位', 'precision' => null, 'fixed' => null],
-        'rank_numeric' => ['type' => 'integer', 'length' => 2, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '段位（数字）', 'precision' => null, 'autoIncrement' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_name' => ['type' => 'unique', 'columns' => ['name'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * @inheritDoc
      */
     public function init(): void

--- a/tests/Fixture/RetentionHistoriesFixture.php
+++ b/tests/Fixture/RetentionHistoriesFixture.php
@@ -9,47 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class RetentionHistoriesFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'title_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'タイトルID', 'precision' => null, 'autoIncrement' => null],
-        'player_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '優勝棋士ID', 'precision' => null, 'autoIncrement' => null],
-        'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '優勝棋士出場国ID', 'precision' => null, 'autoIncrement' => null],
-        'holding' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '期', 'precision' => null, 'autoIncrement' => null],
-        'target_year' => ['type' => 'integer', 'length' => 4, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '対象年', 'precision' => null, 'autoIncrement' => null],
-        'name' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル名', 'precision' => null, 'fixed' => null],
-        'win_group_name' => ['type' => 'string', 'length' => 30, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '優勝チーム名', 'precision' => null, 'fixed' => null],
-        'is_team' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '団体戦判定', 'precision' => null],
-        'acquired' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '取得日', 'precision' => null],
-        'is_official' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '公式戦フラグ', 'precision' => null],
-        'broadcasted' => ['type' => 'date', 'length' => null, 'null' => true, 'default' => null, 'comment' => '放映日', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        'modified_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '最終更新者', 'precision' => null, 'fixed' => null],
-        '_indexes' => [
-            'fk_histories_to_player' => ['type' => 'index', 'columns' => ['player_id'], 'length' => []],
-            'fk_histories_to_country' => ['type' => 'index', 'columns' => ['country_id'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_retention_histories' => ['type' => 'unique', 'columns' => ['title_id', 'holding'], 'length' => []],
-            'fk_histories_to_player' => ['type' => 'foreign', 'columns' => ['player_id'], 'references' => ['players', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'fk_histories_to_country' => ['type' => 'foreign', 'columns' => ['country_id'], 'references' => ['countries', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'fk_histories_to_title' => ['type' => 'foreign', 'columns' => ['title_id'], 'references' => ['titles', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/TableTemplatesFixture.php
+++ b/tests/Fixture/TableTemplatesFixture.php
@@ -11,29 +11,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class TableTemplatesFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // phpcs:disable
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'title' => ['type' => 'string', 'length' => 100, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => 'タイトル', 'precision' => null],
-        'content' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => 'コンテンツ', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時'],
-        'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => '初回登録者', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => '更新日時'],
-        'modified_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => '最終更新者', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8mb4_bin'
-        ],
-    ];
-    // phpcs:enable
-    /**
      * Init method
      *
      * @return void

--- a/tests/Fixture/TitleScoreDetailsFixture.php
+++ b/tests/Fixture/TitleScoreDetailsFixture.php
@@ -9,37 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class TitleScoreDetailsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'title_score_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'タイトル成績ID', 'precision' => null, 'autoIncrement' => null],
-        'player_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '棋士ID', 'precision' => null, 'autoIncrement' => null],
-        'player_name' => ['type' => 'string', 'length' => 20, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '棋士名', 'precision' => null, 'fixed' => null],
-        'division' => ['type' => 'string', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '成績区分', 'precision' => null, 'fixed' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_indexes' => [
-            'fk_details_to_player' => ['type' => 'index', 'columns' => ['player_id'], 'length' => []],
-            'idx_division' => ['type' => 'index', 'columns' => ['division'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_title_score_details' => ['type' => 'unique', 'columns' => ['title_score_id', 'player_id'], 'length' => []],
-            'fk_details_to_player' => ['type' => 'foreign', 'columns' => ['player_id'], 'references' => ['players', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-            'fk_details_to_title_score' => ['type' => 'foreign', 'columns' => ['title_score_id'], 'references' => ['title_scores', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/TitleScoresFixture.php
+++ b/tests/Fixture/TitleScoresFixture.php
@@ -9,41 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class TitleScoresFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '所属国ID', 'precision' => null, 'autoIncrement' => null],
-        'title_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => 'タイトルID', 'precision' => null, 'autoIncrement' => null],
-        'name' => ['type' => 'string', 'length' => 100, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '対局名', 'precision' => null, 'fixed' => null],
-        'result' => ['type' => 'string', 'length' => 30, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '結果', 'precision' => null, 'fixed' => null],
-        'started' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '開始日', 'precision' => null],
-        'ended' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '終了日', 'precision' => null],
-        'is_world' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '国際棋戦かどうか', 'precision' => null],
-        'is_official' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '公式戦フラグ', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        '_indexes' => [
-            'fk_title_scores_to_country' => ['type' => 'index', 'columns' => ['country_id'], 'length' => []],
-            'idx_started' => ['type' => 'index', 'columns' => ['started'], 'length' => []],
-            'idx_ended' => ['type' => 'index', 'columns' => ['ended'], 'length' => []],
-            'idx_is_world' => ['type' => 'index', 'columns' => ['is_world'], 'length' => []],
-        ],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'fk_title_scores_to_country' => ['type' => 'foreign', 'columns' => ['country_id'], 'references' => ['countries', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/TitlesFixture.php
+++ b/tests/Fixture/TitlesFixture.php
@@ -10,43 +10,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class TitlesFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '所属国ID', 'precision' => null, 'autoIncrement' => null],
-        'name' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル名', 'precision' => null, 'fixed' => null],
-        'name_english' => ['type' => 'string', 'length' => 60, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'タイトル名（英語）', 'precision' => null, 'fixed' => null],
-        'holding' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '期', 'precision' => null, 'autoIncrement' => null],
-        'sort_order' => ['type' => 'integer', 'length' => 2, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '並び順', 'precision' => null, 'autoIncrement' => null],
-        'html_file_name' => ['type' => 'string', 'length' => 30, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'htmlファイル名', 'precision' => null, 'fixed' => null],
-        'html_file_holding' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => 'htmlファイル期', 'precision' => null, 'autoIncrement' => null],
-        'html_file_modified' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => 'htmlファイル修正日', 'precision' => null],
-        'remarks' => ['type' => 'string', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => 'その他備考', 'precision' => null, 'fixed' => null],
-        'is_team' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '団体戦判定', 'precision' => null],
-        'is_closed' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '終了済', 'precision' => null],
-        'is_output' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => 'Go News 出力有無', 'precision' => null],
-        'is_official' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '1', 'comment' => '公式戦フラグ', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        'modified_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '最終更新者', 'precision' => null, 'fixed' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_title' => ['type' => 'unique', 'columns' => ['country_id', 'name', 'html_file_name', 'is_closed'], 'length' => []],
-            'fk_title_to_country' => ['type' => 'foreign', 'columns' => ['country_id'], 'references' => ['countries', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/UpdatedPointsFixture.php
+++ b/tests/Fixture/UpdatedPointsFixture.php
@@ -9,33 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class UpdatedPointsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'country_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '所属国ID', 'precision' => null, 'autoIncrement' => null],
-        'target_year' => ['type' => 'integer', 'length' => 4, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '対象年', 'precision' => null, 'autoIncrement' => null],
-        'score_updated' => ['type' => 'date', 'length' => null, 'null' => true, 'default' => null, 'comment' => '成績情報更新日', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時', 'precision' => null],
-        'created_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '初回登録者', 'precision' => null, 'fixed' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '更新日時', 'precision' => null],
-        'modified_by' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '最終更新者', 'precision' => null, 'fixed' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'uq_updated_points' => ['type' => 'unique', 'columns' => ['country_id', 'target_year'], 'length' => []],
-            'fk_updated_points_to_country' => ['type' => 'foreign', 'columns' => ['country_id'], 'references' => ['countries', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
      *
      * @var array

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -12,31 +12,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class UsersFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // phpcs:disable
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => 'サロゲートキー', 'autoIncrement' => true, 'precision' => null],
-        'account' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => 'アカウント', 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 50, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => 'ユーザ名', 'precision' => null],
-        'password' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_bin', 'comment' => 'パスワード', 'precision' => null],
-        'is_admin' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '管理者フラグ', 'precision' => null],
-        'last_logged' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => '最終ログイン日時'],
-        'created' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => '初回登録日時'],
-        'modified' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => '更新日時'],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'account' => ['type' => 'unique', 'columns' => ['account'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8mb4_bin'
-        ],
-    ];
-    // phpcs:enable
-    /**
      * Init method
      *
      * @return void

--- a/tests/TestCase/Controller/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/PlayersControllerTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Test\TestCase\Controller;
 
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -176,7 +176,7 @@ class PlayersControllerTest extends AppTestCase
     public function testCreateFailed()
     {
         $this->enableCsrfToken();
-        $now = Date::now();
+        $now = FrozenDate::now();
         $name = '棋士新規作成' . $now->format('YmdHis');
         $data = [
             'name' => $name,
@@ -208,7 +208,7 @@ class PlayersControllerTest extends AppTestCase
     public function testCreate()
     {
         $this->enableCsrfToken();
-        $now = Date::now();
+        $now = FrozenDate::now();
         $name = '棋士新規作成' . $now->format('YmdHis');
         $data = [
             'name' => $name,
@@ -240,7 +240,7 @@ class PlayersControllerTest extends AppTestCase
     public function testCreateWithContinue()
     {
         $this->enableCsrfToken();
-        $now = Date::now();
+        $now = FrozenDate::now();
         $name = '棋士新規作成' . $now->format('YmdHis');
         $data = [
             'name' => $name,
@@ -280,7 +280,7 @@ class PlayersControllerTest extends AppTestCase
     public function testUpdateFailed()
     {
         $this->enableCsrfToken();
-        $now = Date::now();
+        $now = FrozenDate::now();
         $name = '棋士更新' . $now->format('YmdHis');
         $data = [
             'id' => 1,
@@ -313,7 +313,7 @@ class PlayersControllerTest extends AppTestCase
     public function testUpdate()
     {
         $this->enableCsrfToken();
-        $now = Date::now();
+        $now = FrozenDate::now();
         $name = '棋士更新' . $now->format('YmdHis');
         $data = [
             'id' => 1,

--- a/tests/TestCase/Model/Table/TitleScoreDetailsTableTest.php
+++ b/tests/TestCase/Model/Table/TitleScoreDetailsTableTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Test\TestCase\Model\Table;
 
-use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -210,8 +210,8 @@ class TitleScoreDetailsTableTest extends TestCase
     public function testFindRanking()
     {
         $country = $this->Countries->get(1);
-        $from = Date::createFromDate(2017, 1, 1);
-        $to = Date::createFromDate(2017, 12, 31);
+        $from = FrozenDate::createFromDate(2017, 1, 1);
+        $to = FrozenDate::createFromDate(2017, 12, 31);
         $ranking = $this->TitleScoreDetails->findRanking($country, 20, $from, $to);
 
         $this->assertGreaterThan(0, $ranking->count());
@@ -246,8 +246,8 @@ class TitleScoreDetailsTableTest extends TestCase
     public function testFindRankingNoData()
     {
         $country = $this->Countries->get(1);
-        $from = Date::createFromDate(2018, 1, 1);
-        $to = Date::createFromDate(2018, 12, 31);
+        $from = FrozenDate::createFromDate(2018, 1, 1);
+        $to = FrozenDate::createFromDate(2018, 12, 31);
         $ranking = $this->TitleScoreDetails->findRanking($country, 20, $from, $to);
 
         $this->assertEquals(0, $ranking->count());
@@ -261,8 +261,8 @@ class TitleScoreDetailsTableTest extends TestCase
     public function testRecent()
     {
         $country = $this->Countries->get(1);
-        $from = Date::createFromDate(2017, 1, 1);
-        $to = Date::createFromDate(2017, 12, 31);
+        $from = FrozenDate::createFromDate(2017, 1, 1);
+        $to = FrozenDate::createFromDate(2017, 12, 31);
         $recent = $this->TitleScoreDetails->findRecent($country, $from, $to);
 
         $this->assertNotEquals('', $recent);
@@ -276,8 +276,8 @@ class TitleScoreDetailsTableTest extends TestCase
     public function testRecentNoData()
     {
         $country = $this->Countries->get(1);
-        $from = Date::createFromDate(2018, 1, 1);
-        $to = Date::createFromDate(2018, 12, 31);
+        $from = FrozenDate::createFromDate(2018, 1, 1);
+        $to = FrozenDate::createFromDate(2018, 12, 31);
         $recent = $this->TitleScoreDetails->findRecent($country, $from, $to);
 
         $this->assertEquals('', $recent);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,9 +2,67 @@
 declare(strict_types=1);
 
 /**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.0.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Migrations\TestSuite\Migrator;
+
+/**
  * Test runner bootstrap.
  *
  * Add additional configuration/setup your application needs when running
  * unit tests in this file.
  */
+require dirname(__DIR__) . '/vendor/autoload.php';
+
 require dirname(__DIR__) . '/config/bootstrap.php';
+
+$_SERVER['PHP_SELF'] = '/';
+
+if (empty($_SERVER['HTTP_HOST'])) {
+    Configure::write('App.fullBaseUrl', 'http://localhost');
+}
+
+// DebugKit skips settings these connection config if PHP SAPI is CLI / PHPDBG.
+// But since PagesControllerTest is run with debug enabled and DebugKit is loaded
+// in application, without setting up these config DebugKit errors out.
+ConnectionManager::setConfig('test_debug_kit', [
+    'className' => 'Cake\Database\Connection',
+    'driver' => 'Cake\Database\Driver\Sqlite',
+    'database' => TMP . 'debug_kit.sqlite',
+    'encoding' => 'utf8',
+    'cacheMetadata' => true,
+    'quoteIdentifiers' => false,
+]);
+
+ConnectionManager::alias('test', 'default');
+ConnectionManager::alias('test_debug_kit', 'debug_kit');
+
+// Fixate sessionid early on, as php7.2+
+// does not allow the sessionid to be set after stdout
+// has been written to.
+session_id('cli');
+
+// Use migrations to build test database schema.
+//
+// Will rebuild the database if the migration state differs
+// from the migration history in files.
+//
+// If you are not using CakePHP's migrations you can
+// hook into your migration tool of choice here or
+// load schema from a SQL dump file with
+// use Cake\TestSuite\Fixture\SchemaLoader;
+// (new SchemaLoader())->loadSqlFiles('./tests/schema.sql', 'test');
+(new Migrator())->run();


### PR DESCRIPTION
### 概要

- CakePHP を 4.3 にバージョンアップ

### 対応内容

- cakephp/cakephp と cakephp/migrations を最新にバージョンアップ
- 上記に伴い以下を対応
  - routes の定義方法（Router ではなく RouterBuilder を使う、動的パラメータに `:` ではなく `{}` を使う
  - fixture からスキーマ定義を削除し、テスト実行時にはマイグレーションを実行する
  - action の引数に int が使えるようになったので、id や year など数値を想定しているものの型情報を string から int に変更
  - モデルのロードに loadModel ではなく fetchTable を利用
  - Date / Time ではなく FrozenDate / FrozenTime を利用
  - Command の namespace 変更
  - allowEmpty / notEmpty は allowEmpty* / notEmpty* を利用
