### PR TITLE
refs #979 ページネーションコンポーネントのバグ修正

### DIFF
--- a/resources/assets/scripts/components/Paginator.vue
+++ b/resources/assets/scripts/components/Paginator.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
       return this.currentPage === this.lastPage;
     },
     pageCount(): number {
-      return 9;
+      return Math.min(this.lastPage, 9);
     },
     lastPage(): number {
       return Math.ceil(this.total / this.perPage);
@@ -66,11 +66,11 @@ export default Vue.extend({
       return 5 - (5 - (this.toPage - this.pageCount + 1));
     },
     toPage(): number {
-      if (this.lastPage <= this.pageCount) {
+      if (this.currentPage <= 5) {
         return this.pageCount;
       }
-      if (this.currentPage + 5 <= this.lastPage) {
-        return this.pageCount;
+      if (this.currentPage + 4 <= this.lastPage) {
+        return this.currentPage + 4;
       }
       return this.lastPage;
     },

--- a/resources/assets/scripts/pages/notifications/index.vue
+++ b/resources/assets/scripts/pages/notifications/index.vue
@@ -7,7 +7,7 @@
         </div>
       </li>
     </ul>
-    <paginator v-if="items.length" :current-page="currentPage" :total="total" @change-page="onSearch" />
+    <paginator v-if="items.length" :current-page="currentPage" :per-page="perPage" :total="total" @change-page="onSearch" />
     <div class="search-results">
       <ul class="table-header">
         <li class="table-row">
@@ -55,13 +55,18 @@ export default Vue.extend({
     items: [] as Item[],
     currentPage: 1,
   }),
+  computed: {
+    perPage(): number {
+      return 20;
+    },
+  },
   mounted() {
     this.onSearch(1);
   },
   methods: {
     onSearch(page: number) {
       this.currentPage = page;
-      return axios.get<Response>('/api/notifications', { params: { page, limit: 20 } })
+      return axios.get<Response>('/api/notifications', { params: { page, limit: this.perPage } })
         .then(res => res.data)
         .then(({ response: { total, items } }) => {
           this.total = total;


### PR DESCRIPTION
### 概要

- ページネーションコンポーネントのバグ修正

### 対応内容

- 最大で前後4ページと自ページを表示する
- ページ数が9に満たない場合は全て表示する
- やむを得ないとはいえマジックナンバーを多用しているので後々ちゃんとテスト書く
