### PR TITLE
refs #979 表テンプレート一覧を Vue 側で描画する

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -203,5 +203,11 @@ return static function (RouteBuilder $routes) {
         $routes->scope('/notifications', ['controller' => 'Notifications'], function (RouteBuilder $routes) {
             $routes->get('/', ['action' => 'index'], 'api_notifications');
         });
+
+        // TODO: 全ての action を実装した段階で resources を使う
+        // $routes->resources('table-templates');
+        $routes->scope('/table-templates', ['controller' => 'TableTemplates'], function (RouteBuilder $routes) {
+            $routes->get('/', ['action' => 'index'], 'api_table_templates');
+        });
     });
 };

--- a/resources/assets/scripts/components/table-templates/Item.vue
+++ b/resources/assets/scripts/components/table-templates/Item.vue
@@ -1,0 +1,52 @@
+<template>
+  <li class="table-row">
+    <span class="table-column table-column_title" :title="item.title" v-text="item.title" />
+    <span class="table-column table-column_created" v-text="created" />
+    <span class="table-column table-column_modified" v-text="modified" />
+    <span class="table-column table-column_actions">
+      <a :href="editPageLink" class="layout-button button-secondary">編集</a>
+      <form :name="formName" method="post" :action="editPageLink" style="display: none;">
+        <input type="hidden" name="_method" value="DELETE">
+        <input type="hidden" name="_csrfToken" autocomplete="off" :value="csrfToken">
+      </form>
+      <a href="#" :data-confirm-message="confirmMessage" :onclick="`if (confirm(this.dataset.confirmMessage)) { document.${formName}.submit(); } event.returnValue = false; return false;`" class="layout-button button-danger">削除</a>
+    </span>
+  </li>
+</template>
+
+<script lang="ts">
+import dayjs from 'dayjs';
+import Vue, { PropType } from 'vue';
+
+import { TableTemplate as Item } from '@/types/table-template';
+
+export default Vue.extend({
+  props: {
+    item: {
+      type: Object as PropType<Item>,
+      required: true,
+    },
+    csrfToken: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    created(): string {
+      return dayjs(this.item.created).format('YYYY年MM月DD日 HH時mm分ss秒');
+    },
+    modified(): string {
+      return dayjs(this.item.modified).format('YYYY年MM月DD日 HH時mm分ss秒');
+    },
+    editPageLink(): string {
+      return `/table-templates/${this.item.id}`;
+    },
+    formName(): string {
+      return `table_templates_${this.item.id}`;
+    },
+    confirmMessage(): string {
+      return `ID ${this.item.id} を削除します。よろしいですか?`;
+    },
+  },
+});
+</script>

--- a/resources/assets/scripts/main.ts
+++ b/resources/assets/scripts/main.ts
@@ -12,6 +12,7 @@ import Titles from '@/components/titles/Index.vue';
 import AddHistory from '@/components/titles/AddHistory.vue';
 import Ranks from '@/components/ranks/Index.vue';
 import NotificationListPage from '@/pages/notifications/index.vue';
+import TableTemplateListPage from '@/pages/table-templates/index.vue';
 import { Window } from '@/types';
 
 declare let window: Window;
@@ -32,6 +33,7 @@ const App = new Vue({
     titles: Titles,
     ranks: Ranks,
     NotificationListPage,
+    TableTemplateListPage,
   },
   data: {
     countryId: '',

--- a/resources/assets/scripts/pages/table-templates/index.vue
+++ b/resources/assets/scripts/pages/table-templates/index.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="table-templates index large-9 medium-8 columns content">
+    <ul class="search-header">
+      <li class="search-row">
+        <div class="search-box search-box-right">
+          <a href="/title-templates/new" class="layout-button button-secondary">新規登録</a>
+        </div>
+      </li>
+    </ul>
+    <paginator v-if="items.length" :current-page="currentPage" :per-page="perPage" :total="total" @change-page="onSearch" />
+    <div class="search-results">
+      <ul class="table-header">
+        <li class="table-row">
+          <span class="table-column table-column_title">タイトル</span>
+          <span class="table-column table-column_created">作成日時</span>
+          <span class="table-column table-column_modified"> 修正日時</span>
+          <span class="table-column table-column_actions">操作</span>
+        </li>
+      </ul>
+      <ul v-if="items.length" class="table-body">
+        <template v-for="item in items">
+          <list-item :key="item.id" :item="item" :csrf-token="csrfToken" />
+        </template>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import axios from 'axios';
+
+import Paginator from '@/components/Paginator.vue';
+import ListItem from '@/components/table-templates/Item.vue';
+import {
+  TableTemplate as Item,
+  TableTemplateListResponse as Response,
+} from '@/types/table-template';
+
+export default Vue.extend({
+  components: {
+    Paginator,
+    ListItem,
+  },
+  props: {
+    csrfToken: {
+      type: String,
+      default: '',
+    },
+  },
+  data: () => ({
+    total: 0,
+    items: [] as Item[],
+    currentPage: 1,
+  }),
+  computed: {
+    perPage(): number {
+      return 20;
+    },
+  },
+  mounted() {
+    this.onSearch(1);
+  },
+  methods: {
+    onSearch(page: number) {
+      this.currentPage = page;
+      return axios.get<Response>('/api/table-templates', { params: { page, limit: this.perPage } })
+        .then(res => res.data)
+        .then(({ response: { total, items } }) => {
+          this.total = total;
+          this.items = items;
+        });
+    },
+  },
+});
+</script>

--- a/resources/assets/scripts/types/table-template.ts
+++ b/resources/assets/scripts/types/table-template.ts
@@ -1,0 +1,16 @@
+export interface TableTemplateListResponse {
+  response: TableTemplateList;
+}
+
+export interface TableTemplateList {
+  total: number;
+  items: TableTemplate[];
+}
+
+export interface TableTemplate {
+  id: number;
+  title: string;
+  content: string;
+  created: string;
+  modified: string;
+}

--- a/src/Controller/Api/TableTemplatesController.php
+++ b/src/Controller/Api/TableTemplatesController.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Controller\Api;
+
+/**
+ * TableTemplates Controller
+ *
+ * @property \Gotea\Model\Table\TableTemplatesTable $TableTemplates
+ * @method \Gotea\Model\Entity\TableTemplate[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ */
+class TableTemplatesController extends ApiController
+{
+    /**
+     * Index method
+     *
+     * @return \Cake\Http\Response
+     */
+    public function index()
+    {
+        $query = $this->TableTemplates->find();
+        $tableTemplates = $this->paginate($query);
+
+        return $this->renderJson([
+            'total' => $query->count(),
+            'items' => $tableTemplates->map(function ($item) {
+                return $item->toArray();
+            }),
+        ]);
+    }
+}

--- a/src/Controller/TableTemplatesController.php
+++ b/src/Controller/TableTemplatesController.php
@@ -31,10 +31,6 @@ class TableTemplatesController extends AppController
      */
     public function index(): ?Response
     {
-        $tableTemplates = $this->paginate($this->TableTemplates->find()->orderAsc('title'));
-
-        $this->set(compact('tableTemplates'));
-
         return $this->renderWith('表テンプレート一覧', 'index');
     }
 

--- a/src/Model/Entity/TableTemplate.php
+++ b/src/Model/Entity/TableTemplate.php
@@ -28,9 +28,15 @@ class TableTemplate extends AppEntity
     protected $_accessible = [
         'title' => true,
         'content' => true,
-        'created' => true,
-        'created_by' => true,
+        'created',
         'modified' => true,
-        'modified_by' => true,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected $_hidden = [
+        'created_by',
+        'modified_by',
     ];
 }

--- a/templates/TableTemplates/index.php
+++ b/templates/TableTemplates/index.php
@@ -1,63 +1,6 @@
 <?php
 /**
  * @var \Gotea\View\AppView $this ビューオブジェクト
- * @var \Gotea\Model\Entity\TableTemplate[]|\Cake\Collection\CollectionInterface $tableTemplates 表テンプレートデータ
  */
 ?>
-<div class="table-templates index large-9 medium-8 columns content">
-    <ul class="search-header">
-        <li class="search-row">
-            <div class="search-box search-box-right">
-                <?= $this->Html->link(__('Add'), [
-                    '_name' => 'new_table_template',
-                ], [
-                    'class' => 'layout-button button-secondary',
-                ]) ?>
-            </div>
-        </li>
-    </ul>
-    <?php if (!empty($tableTemplates)) : ?>
-        <?= $this->element('Paginator/default', ['url' => ['_name' => 'table_templates']]) ?>
-    <?php endif ?>
-    <div class="search-results">
-        <ul class="table-header">
-            <li class="table-row">
-                <span class="table-column table-column_title"><?= __('Title') ?></span>
-                <span class="table-column table-column_created"><?= __('Created') ?></span>
-                <span class="table-column table-column_modified"><?= __('Modified') ?></span>
-                <span class="table-column table-column_actions"><?= __('Actions') ?></span>
-            </li>
-        </ul>
-        <?php if (!empty($tableTemplates)) : ?>
-            <ul class="table-body">
-                <?php foreach ($tableTemplates as $tableTemplate) : ?>
-                    <li class="table-row">
-                        <span class="table-column table-column_title" title="<?= h($tableTemplate->title) ?>">
-                            <?= h($tableTemplate->title) ?>
-                        </span>
-                        <span class="table-column table-column_created">
-                            <?= $this->Date->formatToDateTime($tableTemplate->created) ?>
-                        </span>
-                        <span class="table-column table-column_modified">
-                            <?= $this->Date->formatToDateTime($tableTemplate->modified) ?>
-                        </span>
-                        <span class="table-column table-column_actions">
-                            <?= $this->Html->link(__('Edit'), [
-                                '_name' => 'edit_table_template', $tableTemplate->id,
-                            ], [
-                                'class' => 'layout-button button-secondary',
-                            ]) ?>
-                            <?= $this->Form->postLink(__('Delete'), [
-                                '_name' => 'delete_table_template', $tableTemplate->id,
-                            ], [
-                                'method' => 'delete',
-                                'class' => 'layout-button button-danger',
-                                'confirm' => __('Are you sure you want to delete # {0}?', $tableTemplate->id),
-                            ]) ?>
-                        </span>
-                    </li>
-                <?php endforeach ?>
-            </ul>
-        <?php endif ?>
-    </div>
-</div>
+<table-template-list-page csrf-token="<?= $this->request->getAttribute('csrfToken') ?>"></table-template-list-page>

--- a/tests/Fixture/TableTemplatesFixture.php
+++ b/tests/Fixture/TableTemplatesFixture.php
@@ -27,6 +27,15 @@ class TableTemplatesFixture extends TestFixture
                 'modified' => '2020-08-24 16:24:40',
                 'modified_by' => 'Lorem ip',
             ],
+            [
+                'id' => 2,
+                'title' => 'Lorem ipsum dolor sit amet',
+                'content' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.',
+                'created' => '2020-08-24 16:24:40',
+                'created_by' => 'Lorem ip',
+                'modified' => '2020-08-24 16:24:40',
+                'modified_by' => 'Lorem ip',
+            ],
         ];
         parent::init();
     }

--- a/tests/TestCase/Controller/Api/TableTemplatesControllerTest.php
+++ b/tests/TestCase/Controller/Api/TableTemplatesControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Test\TestCase\Controller\Api;
+
+/**
+ * Gotea\Controller\Api\TableTemplatesController Test Case
+ *
+ * @uses \Gotea\Controller\Api\TableTemplatesController
+ */
+class TableTemplatesControllerTest extends ApiTestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'app.TableTemplates',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->createSession();
+    }
+
+    /**
+     * Test index method
+     *
+     * @return void
+     */
+    public function testIndex(): void
+    {
+        $this->get('/api/table-templates?limit=1');
+        $this->assertResponseSuccess();
+        $this->assertNotEquals($this->getEmptyResponse(), $this->_getBodyAsString());
+        $response = json_decode($this->_getBodyAsString())->response;
+        $this->assertEquals($response->total, 2);
+        $this->assertEquals(count($response->items), 1);
+    }
+}


### PR DESCRIPTION
### 概要

- 表テンプレート一覧を Vue 側で描画する

### 対応内容

- /api/table-templates を追加し、Vue 側でこれを利用して html を生成
- /table-templates ではテーブルにアクセスしない
