### PR TITLE
ログローテーションの設定変更

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -3,6 +3,7 @@
 use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use Cake\I18n\FrozenDate;
 use Cake\Log\Engine\FileLog;
 use Cake\Mailer\Transport\SmtpTransport;
 use Gotea\Error\AppExceptionRenderer;
@@ -340,7 +341,9 @@ return [
         'debug' => [
             'className' => FileLog::class,
             'path' => env('LOG_DIR', LOGS),
-            'file' => 'gotea-access',
+            'file' => 'gotea-access_' . FrozenDate::now()->format('Y_m_d'),
+            'size' => '5MB',
+            'rotate' => 7,
             'url' => env('LOG_DEBUG_URL', null),
             'scopes' => false,
             'levels' => ['notice', 'info', 'debug'],
@@ -348,7 +351,9 @@ return [
         'error' => [
             'className' => FileLog::class,
             'path' => env('LOG_DIR', LOGS),
-            'file' => 'gotea-error',
+            'file' => 'gotea-error_' . FrozenDate::now()->format('Y_m_d'),
+            'size' => '5MB',
+            'rotate' => 7,
             'url' => env('LOG_ERROR_URL', null),
             'scopes' => false,
             'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
@@ -357,7 +362,9 @@ return [
         'queries' => [
             'className' => FileLog::class,
             'path' => env('LOG_DIR', LOGS),
-            'file' => 'gotea-query',
+            'file' => 'gotea-query_' . FrozenDate::now()->format('Y_m_d'),
+            'size' => '5MB',
+            'rotate' => 7,
             'url' => env('LOG_QUERIES_URL', null),
             'scopes' => ['queriesLog'],
         ],


### PR DESCRIPTION
### 概要

- 件名の通り

### 対応内容

- 以下の通り変更
  - ログは日付単位で出力
  - 5MB を超えるとローテーション
  - 最大7件残す
