### PR TITLE
merges #1008

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,25 @@ jobs:
         run: npm run lint
 
   test_backend:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
+    # 本来はこの方法でテストを実行したいが、service として立ち上げる MySQL は非 ASCII 文字に対応しておらずエラーになるため一旦断念
+    # container:
+    #   image: ghcr.io/gotoeveryone/composer-php:7.4
+    # services:
+    #   database:
+    #     image: mysql:5.7
+    #     ports:
+    #       - 3306:3306
+    #     env:
+    #       MYSQL_DATABASE: 'gotea_test'
+    #       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    #     options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     env:
       DB_TEST_HOST: '127.0.0.1'
-      DB_TEST_PORT: 3306
+      DB_TEST_PORT: 33306
       DB_TEST_USERNAME: 'root'
-      DB_TEST_PASSWORD: 'password'
+      DB_TEST_PASSWORD: ''
       DB_TEST_NAME: 'gotea_test'
       DB_TEST_ENCODING: 'utf8mb4'
       DB_TEST_TIMEZONE: 'Asia/Tokyo'
@@ -53,21 +66,26 @@ jobs:
       TZ: Asia/Tokyo
       SENTRY_DSN: ''
     steps:
+      - name: Set up MySQL
+        run: >
+          docker run \
+            -e MYSQL_DATABASE=${DB_TEST_NAME} \
+            -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+            -d \
+            -p ${DB_TEST_PORT}:3306 \
+            mysql:5.7 mysqld --character-set-server=${DB_TEST_ENCODING} --collation-server=${DB_TEST_ENCODING}_bin
       - uses: actions/checkout@v1
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
           extensions: zip, intl, pdo_mysql
-      - run: sudo service mysql stop
-      - uses: mirromutth/mysql-action@v1.1
-        with:
-          mysql version: 5.7
-          host port: ${{ env.DB_TEST_PORT }}
-          container port: ${{ env.DB_TEST_PORT }}
-          character set server: ${{ env.DB_TEST_ENCODING }}
-          mysql database: ${{ env.DB_TEST_NAME }}
-          mysql root password: ${{ env.DB_TEST_PASSWORD }}
+          ini-values: xdebug.mode="develop"
+      - name: Wait for MySQL
+        run: |
+          while ! mysqladmin ping --host=${DB_TEST_HOST} --port ${DB_TEST_PORT} --silent; do
+            sleep 1
+          done
       - name: Cache modules
         uses: actions/cache@v2
         id: vendor_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,33 @@ jobs:
 
   test_backend:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gotoeveryone/composer-php:7.4
-    services:
-      database:
-        image: mysql:5.7
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_DATABASE: gotea_test
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    env:
+      DB_TEST_HOST: '127.0.0.1'
+      DB_TEST_PORT: 3306
+      DB_TEST_USERNAME: 'root'
+      DB_TEST_PASSWORD: 'password'
+      DB_TEST_NAME: 'gotea_test'
+      DB_TEST_ENCODING: 'utf8mb4'
+      DB_TEST_TIMEZONE: 'Asia/Tokyo'
+      SECURITY_SALT: ${{ secrets.SECURITY_SALT }}
+      TZ: Asia/Tokyo
+      SENTRY_DSN: ''
     steps:
       - uses: actions/checkout@v1
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          extensions: zip, intl, pdo_mysql
+      - run: sudo service mysql stop
+      - uses: mirromutth/mysql-action@v1.1
+        with:
+          mysql version: 5.7
+          host port: ${{ env.DB_TEST_PORT }}
+          container port: ${{ env.DB_TEST_PORT }}
+          character set server: ${{ env.DB_TEST_ENCODING }}
+          mysql database: ${{ env.DB_TEST_NAME }}
+          mysql root password: ${{ env.DB_TEST_PASSWORD }}
       - name: Cache modules
         uses: actions/cache@v2
         id: vendor_cache

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,10 @@
   "minimum-stability": "stable",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "cakephp/plugin-installer": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "type": "project",
   "license": "MIT",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "abraham/twitteroauth": "^1.1",
     "cakephp/authentication": "^2.0",
     "cakephp/authorization": "^2.0",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -52,10 +52,12 @@ use Dotenv\Exception\InvalidPathException;
  * You can remove this block if you do not want to use environment
  * variables for configuration when deploying.
  */
-try {
-    (new Dotenv(ROOT))->overload();
-} catch (InvalidPathException $e) {
-    die($e->getMessage() . "\n");
+if (file_exists(ROOT . '.env')) {
+    try {
+        (new Dotenv(ROOT))->overload();
+    } catch (InvalidPathException $e) {
+        exit($e->getMessage() . "\n");
+    }
 }
 
 /**
@@ -70,7 +72,7 @@ try {
     Configure::config('default', new PhpConfig());
     Configure::load('app', 'default', false);
 } catch (\Exception $e) {
-    die($e->getMessage() . "\n");
+    exit($e->getMessage() . "\n");
 }
 
 // Load an environment local configuration file.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -52,9 +52,9 @@ use Dotenv\Exception\InvalidPathException;
  * You can remove this block if you do not want to use environment
  * variables for configuration when deploying.
  */
-if (file_exists(ROOT . '.env')) {
+if (file_exists(ENV)) {
     try {
-        (new Dotenv(ROOT))->overload();
+        (new Dotenv(dirname(ENV)))->overload();
     } catch (InvalidPathException $e) {
         exit($e->getMessage() . "\n");
     }

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       TZ: 'Asia/Tokyo'
     ports:
       - '33306:3306'
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
 
 volumes:
   node_modules:


### PR DESCRIPTION
### 概要

- バックエンドのテストが実行されるように

### 対応内容

- `.env` が存在する場合のみ内容をロードするよう修正
- CI では .env ではなく環境変数を利用するよう修正
- ファイルが読み込めないなど後続に影響が出るエラーの場合、終了コードで検知できるよう die ではなく exit を利用するよう修正
- CI で mysql コンテナを利用した際、文字セットが指定できないことでテストがエラーになったため、自前で container を立ち上げてそれを利用してテストするよう修正