### PR TITLE
fix: not load dotenv when set environment variable of `CI`

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -52,7 +52,7 @@ use Dotenv\Exception\InvalidPathException;
  * You can remove this block if you do not want to use environment
  * variables for configuration when deploying.
  */
-if (file_exists(ENV)) {
+if (!env('CI') && file_exists(ENV)) {
     try {
         (new Dotenv(dirname(ENV)))->overload();
     } catch (InvalidPathException $e) {


### PR DESCRIPTION
### 概要

- 

### 対応内容

- 
