### PR TITLE
update cakephp version to 4.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "abraham/twitteroauth": "^4.0",
     "cakephp/authentication": "^2.0",
     "cakephp/authorization": "^2.0",
-    "cakephp/cakephp": "^4.3",
+    "cakephp/cakephp": "^4.4",
     "cakephp/migrations": "^3.2",
     "cakephp/plugin-installer": "^1.0",
     "connehito/cake-sentry": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eae23aa225f7c22fb9dd9e8a8393bde1",
+    "content-hash": "3620ddd7626cf372e640d7c59c9e8e0f",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -204,16 +204,16 @@
         },
         {
             "name": "cakephp/cakephp",
-            "version": "4.3.3",
+            "version": "4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "9bfef5659088c446b2f7bdb612cc321d83779287"
+                "reference": "35b1b52d234ad6ec8cf673c8b143c17895796897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/9bfef5659088c446b2f7bdb612cc321d83779287",
-                "reference": "9bfef5659088c446b2f7bdb612cc321d83779287",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/35b1b52d234ad6ec8cf673c8b143c17895796897",
+                "reference": "35b1b52d234ad6ec8cf673c8b143c17895796897",
                 "shasum": ""
             },
             "require": {
@@ -223,15 +223,15 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "laminas/laminas-diactoros": "^2.2.2",
-                "laminas/laminas-httphandlerrunner": "^1.1",
+                "laminas/laminas-httphandlerrunner": "^1.1 || ^2.0",
                 "league/container": "^4.2.0",
-                "php": ">=7.2.0",
+                "php": ">=7.4.0",
                 "psr/container": "^1.1 || ^2.0",
                 "psr/http-client": "^1.0",
                 "psr/http-server-handler": "^1.0",
                 "psr/http-server-middleware": "^1.0",
-                "psr/log": "^1.0.0",
-                "psr/simple-cache": "^1.0.0"
+                "psr/log": "^1.0 || ^2.0",
+                "psr/simple-cache": "^1.0 || ^2.0"
             },
             "replace": {
                 "cakephp/cache": "self.version",
@@ -264,16 +264,16 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Cake\\": "src/"
-                },
                 "files": [
                     "src/Core/functions.php",
                     "src/Collection/functions.php",
                     "src/I18n/functions.php",
                     "src/Routing/functions.php",
                     "src/Utility/bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Cake\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -304,7 +304,7 @@
                 "issues": "https://github.com/cakephp/cakephp/issues",
                 "source": "https://github.com/cakephp/cakephp"
             },
-            "time": "2021-12-17T16:07:12+00:00"
+            "time": "2022-07-27T00:52:07+00:00"
         },
         {
             "name": "cakephp/chronos",
@@ -7747,5 +7747,5 @@
         "php": ">=7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -35,8 +36,8 @@ use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
-use Cake\Error\ConsoleErrorHandler;
-use Cake\Error\ErrorHandler;
+use Cake\Error\ErrorTrap;
+use Cake\Error\ExceptionTrap;
 use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Mailer\Mailer;
@@ -107,18 +108,16 @@ mb_internal_encoding(Configure::read('App.encoding'));
  */
 ini_set('intl.default_locale', Configure::read('App.defaultLocale'));
 
-/**
+/*
  * Register application error and exception handlers.
  */
-$isCli = PHP_SAPI === 'cli';
-if ($isCli) {
-    (new ConsoleErrorHandler(Configure::read('Error')))->register();
-} else {
-    (new ErrorHandler(Configure::read('Error')))->register();
-}
+(new ErrorTrap(Configure::read('Error')))->register();
+(new ExceptionTrap(Configure::read('Error')))->register();
 
-// Include the CLI bootstrap overrides.
-if ($isCli) {
+/*
+ * Include the CLI bootstrap overrides.
+ */
+if (PHP_SAPI === 'cli') {
     require __DIR__ . '/bootstrap_cli.php';
 }
 
@@ -193,8 +192,8 @@ ServerRequest::addDetector('tablet', function ($request) {
 // TypeFactory::build('timestamptimezone')
 //    ->useMutable();
 TypeFactory::build('date')
-   ->useLocaleParser()
-   ->setLocaleFormat('yyyy/MM/dd');
+    ->useLocaleParser()
+    ->setLocaleFormat('yyyy/MM/dd');
 
 /*
 * Custom Inflector rules, can be set to correctly pluralize or singularize

--- a/src/Controller/Api/ApiController.php
+++ b/src/Controller/Api/ApiController.php
@@ -29,8 +29,6 @@ abstract class ApiController extends Controller
         ]);
         $this->loadComponent('Authorization.Authorization');
 
-        $this->forceJsonResponse();
-
         // 操作ユーザ記録イベントを設定
         $user = $this->getRequest()->getHeaderLine('X-Access-User');
         if ($user) {

--- a/src/Controller/JsonResponseTrait.php
+++ b/src/Controller/JsonResponseTrait.php
@@ -3,23 +3,19 @@ declare(strict_types=1);
 
 namespace Gotea\Controller;
 
+use Cake\View\JsonView;
+
 /**
  * JSON形式のレスポンスを制御します。
- *
- * @property \Cake\Controller\Component\RequestHandlerComponent $RequestHandler
  */
 trait JsonResponseTrait
 {
     /**
-     * アクションのレスポンスをすべてJSON形式に設定します。
-     *
-     * @return void
+     * @inheritDoc
      */
-    public function forceJsonResponse()
+    public function viewClasses(): array
     {
-        $this->loadComponent('RequestHandler');
-
-        $this->RequestHandler->renderAs($this, 'json');
+        return [JsonView::class];
     }
 
     /**

--- a/tests/TestCase/Controller/Api/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/Api/PlayersControllerTest.php
@@ -55,7 +55,7 @@ class PlayersControllerTest extends ApiTestCase
      */
     public function testSearchRanksNoData()
     {
-        $this->get('/api/players/ranks/0');
+        $this->get('/api/players/ranks/999');
         $this->assertResponseSuccess();
         $this->assertResponseEquals($this->getEmptyResponse());
     }


### PR DESCRIPTION
### 概要

- update cakephp version at 4.3.x to 4.4.x
- and change with follow [migration guide](https://book.cakephp.org/4/ja/appendices/4-4-migration-guide.html)
