### PR TITLE
merges #1035

### DIFF
--- a/src/Command/PlayerRankCommand.php
+++ b/src/Command/PlayerRankCommand.php
@@ -11,7 +11,6 @@ use Cake\Log\Log;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;
 use Goutte\Client;
-use GuzzleHttp\Client as GuzzleClient;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
@@ -202,7 +201,6 @@ class PlayerRankCommand extends Command
     private function getCrawler($url)
     {
         $client = new Client();
-        $client->setClient(new GuzzleClient());
 
         return $client->request('GET', $url);
     }

--- a/src/Command/RankDiffCommand.php
+++ b/src/Command/RankDiffCommand.php
@@ -15,7 +15,6 @@ use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Gotea\Model\Entity\Country;
 use Goutte\Client;
-use GuzzleHttp\Client as GuzzleClient;
 use Symfony\Component\DomCrawler\Crawler;
 use Throwable;
 
@@ -264,7 +263,6 @@ class RankDiffCommand extends Command
     private function getCrawler($url)
     {
         $client = new Client();
-        $client->setClient(new GuzzleClient());
 
         $crawler = $client->request('GET', $url);
         if ($client->getInternalResponse()->getStatusCode() >= 400) {


### PR DESCRIPTION
### 概要

- #320 のマージによりエラーになった問題の解消

### 対応内容

- GuzzleClient および setClient を利用しないよう修正
- Goutte 4.0 で Symfony の HttpClient を利用するようになったため、それに追従
