### PR TITLE
merges #1036

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
       "@test",
       "@cs-check"
     ],
-    "cs-check": "phpcs --colors -p  src/ tests/",
+    "cs-check": "phpcs --colors -p src/ tests/",
     "cs-fix": "phpcbf --colors -p src/ tests/",
     "test": "phpunit --colors=always"
   },

--- a/config/app.php
+++ b/config/app.php
@@ -1,11 +1,15 @@
 <?php
+declare(strict_types=1);
 
 use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use Cake\Http\Exception\MissingControllerException;
+use Cake\Http\Exception\NotFoundException;
 use Cake\I18n\FrozenDate;
 use Cake\Log\Engine\FileLog;
 use Cake\Mailer\Transport\SmtpTransport;
+use Cake\Routing\Exception\MissingRouteException;
 use Gotea\Error\AppExceptionRenderer;
 
 return [
@@ -196,7 +200,11 @@ return [
     'Error' => [
         'errorLevel' => E_ALL & ~E_USER_DEPRECATED,
         'exceptionRenderer' => AppExceptionRenderer::class,
-        'skipLog' => [],
+        'skipLog' => [
+            NotFoundException::class,
+            MissingRouteException::class,
+            MissingControllerException::class,
+        ],
         'log' => true,
         'trace' => true,
     ],


### PR DESCRIPTION
### 概要

- 404 エラーが起きた際に Sentry に通知されないようにした

### 対応内容

- `skipLog` に 404 系例外を追加
