### PR TITLE
Sentry.dsn が設定されている場合のみ CakeSentry プラグインを有効化する

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -76,7 +76,10 @@ class Application extends BaseApplication implements
         $this->addPlugin('Shim');
         $this->addPlugin('Authentication');
         $this->addPlugin('Authorization');
-        $this->addPlugin('Connehito/CakeSentry');
+
+        if (Configure::read('Sentry.dsn')) {
+            $this->addPlugin('Connehito/CakeSentry');
+        }
     }
 
     /**

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 namespace Gotea\Controller;
 
 use Cake\Controller\ErrorController as BaseErrorController;
-use Cake\Log\Log;
-use PDOException;
-use Throwable;
 
 /**
  * アプリの共通例外コントローラ
  *
- * @author  Kazuki Kamizuru
- * @since   2016/12/28
+ * @property \Cake\Controller\Component\FlashComponent $Flash
  */
 class ErrorController extends BaseErrorController
 {
@@ -26,21 +22,5 @@ class ErrorController extends BaseErrorController
         parent::initialize();
 
         $this->loadComponent('Flash');
-    }
-
-    /**
-     * ロールバック処理を行います。
-     *
-     * @param \Exception $exception 例外
-     * @return void
-     */
-    public function rollback(Throwable $exception)
-    {
-        Log::error("Error Code: {$exception->getCode()}");
-        Log::error($exception->getMessage());
-
-        if ($exception instanceof PDOException) {
-            $this->Flash->error(__('Executing query failed.<br/>Please confirm logfile.'));
-        }
     }
 }

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -3,26 +3,30 @@ declare(strict_types=1);
 
 namespace Gotea\Error;
 
-use Cake\Error\ExceptionRenderer;
+use Cake\Error\Renderer\WebExceptionRenderer;
+use PDOException;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Exception発生時のレンダラクラス
  *
  * @property \Gotea\Controller\ErrorController $controller
  */
-class AppExceptionRenderer extends ExceptionRenderer
+class AppExceptionRenderer extends WebExceptionRenderer
 {
     /**
      * @inheritDoc
      */
     public function render(): ResponseInterface
     {
-        $this->controller->rollback($this->error);
-
-        // JSONリクエストの場合
         if ($this->controller->getRequest()->is('json')) {
             return $this->controller->renderError($this->error->getCode());
+        }
+
+        if ($this->error instanceof PDOException) {
+            $this->controller->log($this->error->getMessage(), LogLevel::ERROR);
+            $this->controller->Flash->error(__('Executing query failed.<br/>Please confirm logfile.'));
         }
 
         return parent::render();

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -5,6 +5,7 @@ namespace Gotea\Test\TestCase;
 
 use Authentication\Middleware\AuthenticationMiddleware;
 use Authorization\Middleware\AuthorizationMiddleware;
+use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\Middleware\BodyParserMiddleware;
 use Cake\Http\MiddlewareQueue;
@@ -32,7 +33,7 @@ class ApplicationTest extends TestCase
         $app->bootstrap();
         $plugins = $app->getPlugins();
 
-        $this->assertCount(8, $plugins);
+        $this->assertCount(7, $plugins);
         $this->assertSame('Bake', $plugins->get('Bake')->getName());
         $this->assertSame('Migrations', $plugins->get('Migrations')->getName());
         $this->assertSame('Cake/Repl', $plugins->get('Cake/Repl')->getName());
@@ -40,6 +41,9 @@ class ApplicationTest extends TestCase
         $this->assertSame('Shim', $plugins->get('Shim')->getName());
         $this->assertSame('Authentication', $plugins->get('Authentication')->getName());
         $this->assertSame('Authorization', $plugins->get('Authorization')->getName());
+        $this->assertFalse($plugins->has('Connehito/CakeSentry'));
+
+        Configure::write('Sentry.dsn', 'hogefuga');
         $this->assertSame('Connehito/CakeSentry', $plugins->get('Connehito/CakeSentry')->getName());
     }
 
@@ -60,6 +64,7 @@ class ApplicationTest extends TestCase
         $app->method('addPlugin')
             ->will($this->throwException(new InvalidArgumentException('test exception.')));
 
+        /** @var \Gotea\Application $app */
         $app->bootstrap();
     }
 


### PR DESCRIPTION
### 概要

- CakeSentry プラグインが有効化された場合、もともと設定してたエラーログが一切出力されなくなる

### 対応内容

- 開発時は Sentry を使わないのでプラグインを無効化し、プロダクション環境では有効化するよう対応
