### PR TITLE
デプロイ時の actions/checkout バージョンを固定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     container:
       image: node:16.16.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v1 # vite のビルドで Permission denied になるため actions/checkout@v3 が使えない
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
         with:


### PR DESCRIPTION
### 概要

- `vite build` で permission denied エラーが出る問題を解消する

### 対応内容

- デプロイ時は `actions/checkout@v1` を利用するよう対応