### PR TITLE
merges #1072

### DIFF
--- a/resources/assets/scripts/pages/notifications/index.vue
+++ b/resources/assets/scripts/pages/notifications/index.vue
@@ -56,7 +56,7 @@ export default defineComponent({
     total: 0,
     items: [] as Item[],
     currentPage: 1,
-    perPage: 20,
+    perPage: 30,
   }),
   mounted() {
     const url = new URL(location.href);

--- a/resources/assets/scripts/pages/notifications/index.vue
+++ b/resources/assets/scripts/pages/notifications/index.vue
@@ -39,6 +39,7 @@ import { defineComponent } from 'vue';
 import Paginator from '@/components/Paginator.vue';
 import ListItem from '@/components/notifications/Item.vue';
 import { Notification as Item, NotificationListResponse as Response } from '@/types/notification';
+import { isPositiveNumber } from '@/util/validator';
 
 export default defineComponent({
   components: {
@@ -55,14 +56,19 @@ export default defineComponent({
     total: 0,
     items: [] as Item[],
     currentPage: 1,
+    perPage: 20,
   }),
-  computed: {
-    perPage(): number {
-      return 20;
-    },
-  },
   mounted() {
-    this.onSearch(1);
+    const url = new URL(location.href);
+    const limit = url.searchParams.get('limit');
+    const page = url.searchParams.get('page');
+    if (isPositiveNumber(limit)) {
+      this.perPage = Number.parseInt(limit as string, 10);
+    }
+    if (isPositiveNumber(page)) {
+      this.currentPage = Number.parseInt(page as string, 10);
+    }
+    this.onSearch(this.currentPage);
   },
   methods: {
     onSearch(page: number) {
@@ -73,6 +79,12 @@ export default defineComponent({
         .then(({ response: { total, items } }) => {
           this.total = total;
           this.items = items;
+          const url = new URL(location.href);
+          url.searchParams.set('limit', this.perPage.toString());
+          url.searchParams.set('page', this.currentPage.toString());
+          if (url.toString() !== location.href) {
+            history.replaceState({ page: this.currentPage, limit: this.perPage }, '', url);
+          }
         });
     },
   },

--- a/resources/assets/scripts/pages/table-templates/index.vue
+++ b/resources/assets/scripts/pages/table-templates/index.vue
@@ -40,6 +40,7 @@ import {
   TableTemplate as Item,
   TableTemplateListResponse as Response,
 } from '@/types/table-template';
+import { isPositiveNumber } from '@/util/validator';
 
 export default defineComponent({
   components: {
@@ -56,14 +57,19 @@ export default defineComponent({
     total: 0,
     items: [] as Item[],
     currentPage: 1,
+    perPage: 20,
   }),
-  computed: {
-    perPage(): number {
-      return 20;
-    },
-  },
   mounted() {
-    this.onSearch(1);
+    const url = new URL(location.href);
+    const limit = url.searchParams.get('limit');
+    const page = url.searchParams.get('page');
+    if (isPositiveNumber(limit)) {
+      this.perPage = Number.parseInt(limit as string, 10);
+    }
+    if (isPositiveNumber(page)) {
+      this.currentPage = Number.parseInt(page as string, 10);
+    }
+    this.onSearch(this.currentPage);
   },
   methods: {
     onSearch(page: number) {
@@ -74,6 +80,12 @@ export default defineComponent({
         .then(({ response: { total, items } }) => {
           this.total = total;
           this.items = items;
+          const url = new URL(location.href);
+          url.searchParams.set('limit', this.perPage.toString());
+          url.searchParams.set('page', this.currentPage.toString());
+          if (url.toString() !== location.href) {
+            history.replaceState({ page: this.currentPage, limit: this.perPage }, '', url);
+          }
         });
     },
   },

--- a/resources/assets/scripts/pages/table-templates/index.vue
+++ b/resources/assets/scripts/pages/table-templates/index.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     total: 0,
     items: [] as Item[],
     currentPage: 1,
-    perPage: 20,
+    perPage: 30,
   }),
   mounted() {
     const url = new URL(location.href);

--- a/resources/assets/scripts/util/validator.ts
+++ b/resources/assets/scripts/util/validator.ts
@@ -1,0 +1,1 @@
+export const isPositiveNumber = (value?: string | null) => value != null && /^\d+$/.test(value);


### PR DESCRIPTION
### 概要

- ページ変更時に URL を書き換える

### 対応内容

- お知らせ一覧・テンプレート一覧において、ページ変更時に URL を変更する
- 上記 URL に直接アクセスした場合、該当ページのデータを表示する
- ついでに上限を20から30に変更
