### PR TITLE
段位差分の取得処理をサブコマンド化した

### DIFF
--- a/src/Command/RankDiffCommand.php
+++ b/src/Command/RankDiffCommand.php
@@ -9,24 +9,20 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Http\Client as HttpClient;
-use Cake\Http\Exception\HttpException;
 use Cake\Log\Log;
-use Cake\Utility\Hash;
-use Cake\Utility\Inflector;
+use Gotea\Command\SubCommand\RankDiffJapanSubCommand;
+use Gotea\Command\SubCommand\RankDiffKoreaSubCommand;
+use Gotea\Command\SubCommand\RankDiffSubCommandInterface;
+use Gotea\Command\SubCommand\RankDiffTaiwanSubCommand;
 use Gotea\Model\Entity\Country;
-use Goutte\Client;
-use Symfony\Component\DomCrawler\Crawler;
+use LogicException;
 use Throwable;
 
 /**
  * 段位の差分を抽出するコマンド
  *
- * @property \Gotea\Model\Table\PlayersTable $Players
  * @property \Gotea\Model\Table\CountriesTable $Countries
  * @property \Gotea\Model\Table\RanksTable $Ranks
- * @property \Gotea\Model\Table\OrganizationsTable $Organizations
- *
- * phpcs:disable SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
  */
 class RankDiffCommand extends Command
 {
@@ -36,38 +32,32 @@ class RankDiffCommand extends Command
     public function initialize(): void
     {
         parent::initialize();
-        $this->Players = $this->fetchTable('Players');
         $this->Countries = $this->fetchTable('Countries');
         $this->Ranks = $this->fetchTable('Ranks');
-        $this->Organizations = $this->fetchTable('Organizations');
     }
 
     /**
-     * メイン処理
-     *
-     * @param \Cake\Console\Arguments $args 引数
-     * @param \Cake\Console\ConsoleIo $io 入出力
-     * @return int Success or error code.
+     * @inheritDoc
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
         $url = Configure::read('App.slack.notifyUrl');
         $client = new HttpClient();
         try {
-            $countries = $this->Countries->find()->where(['name in' => ['日本', '韓国', '台湾']]);
+            $countries = $this->Countries->find()->where(['name_english in' => ['Japan', 'Korea', 'Taiwan']]);
             $ranks = $this->Ranks->findProfessional()
                 ->all()
                 ->combine('name', 'rank_numeric')
                 ->toArray();
-            $results = $countries->all()->combine('name', function ($item) use ($client, $ranks) {
-                Log::info("{$item->name}棋士の差分を抽出します。");
-                $method = 'getPlayersFrom' . Inflector::humanize($item->name_english);
-                $diffs = $this->$method($client, $item, $ranks);
-                if (!count($diffs)) {
+            $results = $countries->all()->combine('name', function ($country) use ($client, $ranks) {
+                Log::info("{$country->name}棋士の差分を抽出します。");
+                $subCommand = $this->getSubCommand($country);
+                $players = $subCommand->getPlayers($client, $ranks);
+                if (!count($players)) {
                     return [];
                 }
 
-                return $this->getDiff($item, $diffs);
+                return $this->getDiff($subCommand, $players);
             });
 
             if ($url && !$results->unfold()->isEmpty()) {
@@ -103,19 +93,36 @@ class RankDiffCommand extends Command
     }
 
     /**
-     * 差分データを設定します。
+     * サブコマンドを取得する
      *
      * @param \Gotea\Model\Entity\Country $country 所属国
+     * @return \Gotea\Command\SubCommand\RankDiffSubCommandInterface
+     * @throws \LogicException
+     */
+    private function getSubCommand(Country $country): RankDiffSubCommandInterface
+    {
+        switch ($country->name_english) {
+            case 'Japan':
+                return new RankDiffJapanSubCommand($country);
+            case 'Korea':
+                return new RankDiffKoreaSubCommand($country);
+            case 'Taiwan':
+                return new RankDiffTaiwanSubCommand($country);
+            default:
+                throw new LogicException("not implemented subcommand [{$country->name_english}]");
+        }
+    }
+
+    /**
+     * 差分データを設定します。
+     *
+     * @param \Gotea\Command\SubCommand\RankDiffSubCommandInterface $subCommand サブコマンド
      * @param array $results 抽出結果
      * @return array
      */
-    private function getDiff($country, $results)
+    private function getDiff(RankDiffSubCommandInterface $subCommand, array $results): array
     {
-        // 台湾の場合は台湾棋院のみを対象とする
-        $organization = $country->code === 'tw' ? $this->Organizations->findByName('台湾棋院')->first() : null;
-
-        return $this->Players->findRanksCount($country->id, $organization ? $organization->id : null)
-            ->all()
+        return $subCommand->getRankSummary()
             ->map(function ($item) use ($results) {
                 $item->web_count = count($results[$item->rank]) ?? 0;
 
@@ -125,206 +132,6 @@ class RankDiffCommand extends Command
             })->map(function ($item) {
                 return "　{$item->name} WEB: {$item->web_count} - DB: {$item->count}";
             })->toArray();
-    }
-
-    /**
-     * 日本棋士の段位と棋士数を取得
-     *
-     * @param \Cake\Http\Client $client HTTP クライアント
-     * @param \Gotea\Model\Entity\Country $country 所属国
-     * @param array $ranks 段位一覧
-     * @return array 段位と棋士の一覧
-     */
-    private function getPlayersFromJapan(HttpClient $client, Country $country, array $ranks)
-    {
-        // 日本棋院・関西棋院それぞれから棋士一覧を取得
-        $nihonkiin = $this->getPlayersFromNihonKiin($ranks);
-        $kansaikiin = $this->getPlayersFromKansaiKiin($ranks);
-        // 対象の段位を取得
-        // タイトル者がどちらかにしかいないケースを考慮し、rankText の値をマージしたうえで重複を排除する
-        $rankTexts = array_unique(
-            Hash::merge(
-                Hash::extract($nihonkiin, '{n}.rankText'),
-                Hash::extract($kansaikiin, '{n}.rankText')
-            )
-        );
-
-        $results = Hash::map($rankTexts, '{n}', function ($rankText) use ($ranks, $nihonkiin, $kansaikiin) {
-            return [
-                'rankText' => $rankText,
-                'rank' => Hash::get($ranks, $rankText),
-                'players' => Hash::merge(
-                    collection($nihonkiin)
-                        ->filter(function ($item) use ($rankText) {
-                            return Hash::get($item, 'rankText') === $rankText;
-                        })
-                        ->extract('players')
-                        ->unfold()
-                        ->toList(),
-                    collection($kansaikiin)
-                        ->filter(function ($item) use ($rankText) {
-                            return Hash::get($item, 'rankText') === $rankText;
-                        })
-                        ->extract('players')
-                        ->unfold()
-                        ->toList()
-                ),
-            ];
-        });
-
-        // 段位が設定されていない場合は DB から段位を割り当てる
-        foreach ($results as $item) {
-            if ($item['rank'] === null) {
-                foreach ($item['players'] as $name) {
-                    $player = $this->Players->findRankByNamesAndCountries(
-                        [$name, str_replace('　', '', $name)],
-                        $country->id
-                    );
-                    foreach ($results as $idx => $data) {
-                        if ($data['rank'] === $player->rank->rank_numeric) {
-                            $results[$idx]['players'][] = $player->name;
-                        }
-                    }
-                }
-            }
-        }
-
-        return collection($results)->filter(function ($item) {
-            return $item['rank'];
-        })->combine('rank', 'players')->toArray();
-    }
-
-    /**
-     * 韓国棋士の段位と棋士数を取得
-     *
-     * @param \Cake\Http\Client $client HTTP クライアント
-     * @param \Gotea\Model\Entity\Country $country 所属国
-     * @param array $ranks 段位一覧
-     * @return array 段位と棋士の一覧
-     */
-    private function getPlayersFromKorea(HttpClient $client, Country $country, array $ranks)
-    {
-        $url = Configure::read('App.diffUrl.korea');
-
-        return collection(array_reverse(range(1, 9)))->map(function (int $rank) use ($client, $url) {
-            $response = $client->get($url, [
-                'q' => "nation=1,ob_forc={$rank}",
-            ]);
-
-            return [
-                'rank' => $rank,
-                'players' => array_map(function ($item) {
-                    return $item['prpl_name'];
-                }, $response->getJson()['recordset']),
-            ];
-        })->combine('rank', 'players')->toArray();
-    }
-
-    /**
-     * 台湾棋士の段位と棋士数を取得
-     *
-     * @param \Cake\Http\Client $client HTTP クライアント
-     * @param \Gotea\Model\Entity\Country $country 所属国
-     * @param array $ranks 段位一覧
-     * @return array 段位と棋士の一覧
-     */
-    private function getPlayersFromTaiwan(HttpClient $client, Country $country, array $ranks)
-    {
-        $results = [];
-        $rank = null;
-        $crawler = $this->getCrawler(Configure::read('App.diffUrl.taiwan'));
-        $crawler->filter('.post-body.entry-content div:first-child > div')
-            ->each(function (Crawler $node) use (&$results, &$rank, $ranks) {
-                // テキストが設定されている場合のみ処理する
-                $text = trim($node->text());
-                if ($text) {
-                    $matches = [];
-                    if (preg_match('/(.*段).*\(\d+\)/', $text, $matches)) {
-                        $rank = Hash::get($ranks, $matches[1]);
-                    } else {
-                        $players = Hash::filter($node->filter('a')->each(function ($node) {
-                            return trim(preg_replace("/\s+/u", '', $node->text()));
-                        }), function ($name) {
-                            return !empty($name);
-                        });
-                        if ($players) {
-                            $results[$rank] = Hash::merge(Hash::get($results, $rank, []), $players);
-                        }
-                    }
-                }
-            });
-
-        return $results;
-    }
-
-    /**
-     * URLからCrawlerオブジェクトを返却
-     *
-     * @param string $url URL
-     * @return \Symfony\Component\DomCrawler\Crawler
-     * @throws \Cake\Http\Exception\HttpException
-     */
-    private function getCrawler($url)
-    {
-        $client = new Client();
-
-        $crawler = $client->request('GET', $url);
-        if ($client->getInternalResponse()->getStatusCode() >= 400) {
-            throw new HttpException(
-                'クロール先のページが意図しないレスポンスを返しました。',
-                $client->getInternalResponse()->getStatusCode()
-            );
-        }
-
-        return $crawler;
-    }
-
-    /**
-     * 日本棋院の棋士一覧を取得
-     *
-     * @param array $ranks 段位一覧
-     * @return array 日本棋院の棋士一覧
-     */
-    private function getPlayersFromNihonKiin(array $ranks)
-    {
-        $crawler = $this->getCrawler(Configure::read('App.diffUrl.japan'));
-
-        return $crawler->filter('#content h2')->each(function (Crawler $node) use ($ranks) {
-            $rankText = $node->text();
-            $rank = Hash::get($ranks, $rankText);
-            $players = $node->nextAll()->filter('.ul_players')->first()
-                ->filter('li')->each(function (Crawler $cell) {
-                    return $cell->text();
-                });
-
-            return compact('rankText', 'rank', 'players');
-        });
-    }
-
-    /**
-     * 関西棋院の棋士一覧を取得
-     *
-     * @param array $ranks 段位一覧
-     * @return array 関西棋院の棋士一覧
-     */
-    private function getPlayersFromKansaiKiin(array $ranks)
-    {
-        $crawler = $this->getCrawler(Configure::read('App.diffUrl.kansai'));
-
-        return collection($crawler->filter('.prokisi_table table')->each(function (Crawler $table) use ($ranks) {
-            $rankText = $table->filter('thead th')->first()->text();
-            $rank = Hash::get($ranks, $rankText);
-            $players = collection($table->filter('tbody td')->each(function (Crawler $cell) {
-                return $cell->text();
-            }))->filter(function ($value) {
-                return mb_strlen($value) > 0;
-            })->toArray();
-
-            return compact('rankText', 'rank', 'players');
-        }))->filter(function ($item) {
-            // 退役者や物故者は除く
-            return $item['rank'] || $item['rankText'] === 'タイトル者';
-        })->toArray();
     }
 
     /**
@@ -341,7 +148,7 @@ class RankDiffCommand extends Command
             implode("\n", $messages->filter(function ($values, $key) {
                 return count($values) > 0;
             })->map(function ($values, $key) {
-                return implode("\n", array_merge(["【${key}】"], array_map(function ($value) {
+                return implode("\n", array_merge(["【{$key}】"], array_map(function ($value) {
                     return $value;
                 }, array_values($values))));
             })->toArray()),

--- a/src/Command/SubCommand/RankDiffJapanSubCommand.php
+++ b/src/Command/SubCommand/RankDiffJapanSubCommand.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Command\SubCommand;
+
+use Cake\Core\Configure;
+use Cake\Datasource\ResultSetInterface;
+use Cake\Http\Client as HttpClient;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+use Gotea\Model\Entity\Country;
+use Symfony\Component\DomCrawler\Crawler;
+
+class RankDiffJapanSubCommand implements RankDiffSubCommandInterface
+{
+    use RankDiffTrait;
+
+    /**
+     * @var \Gotea\Model\Entity\Country
+     */
+    private Country $country;
+
+    /**
+     * Constructor
+     *
+     * @param \Gotea\Model\Entity\Country $country 所属国
+     */
+    public function __construct(Country $country)
+    {
+        $this->country = $country;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPlayers(HttpClient $client, array $ranks): array
+    {
+        // 日本棋院・関西棋院それぞれから棋士一覧を取得
+        $nihonkiin = $this->getPlayersFromNihonKiin($ranks);
+        $kansaikiin = $this->getPlayersFromKansaiKiin($ranks);
+        // 対象の段位を取得
+        // タイトル者がどちらかにしかいないケースを考慮し、rankText の値をマージしたうえで重複を排除する
+        $rankTexts = array_unique(
+            Hash::merge(
+                Hash::extract($nihonkiin, '{n}.rankText'),
+                Hash::extract($kansaikiin, '{n}.rankText')
+            )
+        );
+
+        $results = Hash::map($rankTexts, '{n}', function ($rankText) use ($ranks, $nihonkiin, $kansaikiin) {
+            return [
+                'rankText' => $rankText,
+                'rank' => Hash::get($ranks, $rankText),
+                'players' => Hash::merge(
+                    collection($nihonkiin)
+                        ->filter(function ($item) use ($rankText) {
+                            return Hash::get($item, 'rankText') === $rankText;
+                        })
+                        ->extract('players')
+                        ->unfold()
+                        ->toList(),
+                    collection($kansaikiin)
+                        ->filter(function ($item) use ($rankText) {
+                            return Hash::get($item, 'rankText') === $rankText;
+                        })
+                        ->extract('players')
+                        ->unfold()
+                        ->toList()
+                ),
+            ];
+        });
+
+        /** @var \Gotea\Model\Table\PlayersTable $players */
+        $players = TableRegistry::getTableLocator()->get('Players');
+
+        // 段位が設定されていない場合は DB から段位を割り当てる
+        foreach ($results as $item) {
+            if ($item['rank'] === null) {
+                foreach ($item['players'] as $name) {
+                    $player = $players->findRankByNamesAndCountries(
+                        [$name, str_replace('　', '', $name)],
+                        $this->country->id
+                    );
+                    foreach ($results as $idx => $data) {
+                        if ($data['rank'] === $player->rank->rank_numeric) {
+                            $results[$idx]['players'][] = $player->name;
+                        }
+                    }
+                }
+            }
+        }
+
+        return collection($results)->filter(function ($item) {
+            return $item['rank'];
+        })->combine('rank', 'players')->toArray();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRankSummary(): ResultSetInterface
+    {
+        /** @var \Gotea\Model\Table\PlayersTable $players */
+        $players = TableRegistry::getTableLocator()->get('Players');
+
+        return $players->findRanksCount($this->country->id, null)->all();
+    }
+
+    /**
+     * 日本棋院の棋士一覧を取得
+     *
+     * @param array $ranks 段位一覧
+     * @return array 日本棋院の棋士一覧
+     */
+    private function getPlayersFromNihonKiin(array $ranks): array
+    {
+        $crawler = $this->getCrawler(Configure::read('App.diffUrl.japan'));
+
+        return $crawler->filter('#content h2')->each(function (Crawler $node) use ($ranks) {
+            $rankText = $node->text();
+            $rank = Hash::get($ranks, $rankText);
+            $players = $node->nextAll()->filter('.ul_players')->first()
+                ->filter('li')->each(function (Crawler $cell) {
+                    return $cell->text();
+                });
+
+            return compact('rankText', 'rank', 'players');
+        });
+    }
+
+    /**
+     * 関西棋院の棋士一覧を取得
+     *
+     * @param array $ranks 段位一覧
+     * @return array 関西棋院の棋士一覧
+     */
+    private function getPlayersFromKansaiKiin(array $ranks): array
+    {
+        $crawler = $this->getCrawler(Configure::read('App.diffUrl.kansai'));
+
+        return collection($crawler->filter('.prokisi_table table')->each(function (Crawler $table) use ($ranks) {
+            $rankText = $table->filter('thead th')->first()->text();
+            $rank = Hash::get($ranks, $rankText);
+            $players = collection($table->filter('tbody td')->each(function (Crawler $cell) {
+                return $cell->text();
+            }))->filter(function ($value) {
+                return mb_strlen($value) > 0;
+            })->toArray();
+
+            return compact('rankText', 'rank', 'players');
+        }))->filter(function ($item) {
+            // 退役者や物故者は除く
+            return $item['rank'] || $item['rankText'] === 'タイトル者';
+        })->toArray();
+    }
+}

--- a/src/Command/SubCommand/RankDiffKoreaSubCommand.php
+++ b/src/Command/SubCommand/RankDiffKoreaSubCommand.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Command\SubCommand;
+
+use Cake\Core\Configure;
+use Cake\Datasource\ResultSetInterface;
+use Cake\Http\Client as HttpClient;
+use Cake\ORM\TableRegistry;
+use Gotea\Model\Entity\Country;
+
+class RankDiffKoreaSubCommand implements RankDiffSubCommandInterface
+{
+    use RankDiffTrait;
+
+    /**
+     * @var \Gotea\Model\Entity\Country
+     */
+    private Country $country;
+
+    /**
+     * Constructor
+     *
+     * @param \Gotea\Model\Entity\Country $country 所属国
+     */
+    public function __construct(Country $country)
+    {
+        $this->country = $country;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPlayers(HttpClient $client, array $ranks): array
+    {
+        $url = Configure::read('App.diffUrl.korea');
+
+        return collection(array_reverse(range(1, 9)))->map(function (int $rank) use ($client, $url) {
+            $response = $client->get($url, [
+                'q' => "nation=1,ob_forc={$rank}",
+            ]);
+
+            return [
+                'rank' => $rank,
+                'players' => array_map(function ($item) {
+                    return $item['prpl_name'];
+                }, $response->getJson()['recordset']),
+            ];
+        })->combine('rank', 'players')->toArray();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRankSummary(): ResultSetInterface
+    {
+        /** @var \Gotea\Model\Table\PlayersTable $players */
+        $players = TableRegistry::getTableLocator()->get('Players');
+
+        return $players->findRanksCount($this->country->id, null)->all();
+    }
+}

--- a/src/Command/SubCommand/RankDiffSubCommandInterface.php
+++ b/src/Command/SubCommand/RankDiffSubCommandInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Command\SubCommand;
+
+use Cake\Datasource\ResultSetInterface;
+use Cake\Http\Client as HttpClient;
+
+interface RankDiffSubCommandInterface
+{
+    /**
+     * 棋士情報を取得する
+     *
+     * @param \Cake\Http\Client $client HTTP クライアント
+     * @param array $ranks 段位一覧
+     * @return array 段位と棋士の一覧
+     */
+    public function getPlayers(HttpClient $client, array $ranks): array;
+
+    /**
+     * 段位ごとの集計結果を取得する
+     *
+     * @return \Cake\Datasource\ResultSetInterface 段位の集計結果
+     */
+    public function getRankSummary(): ResultSetInterface;
+}

--- a/src/Command/SubCommand/RankDiffTaiwanSubCommand.php
+++ b/src/Command/SubCommand/RankDiffTaiwanSubCommand.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Command\SubCommand;
+
+use Cake\Core\Configure;
+use Cake\Datasource\ResultSetInterface;
+use Cake\Http\Client as HttpClient;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+use Gotea\Model\Entity\Country;
+use Symfony\Component\DomCrawler\Crawler;
+
+class RankDiffTaiwanSubCommand implements RankDiffSubCommandInterface
+{
+    use RankDiffTrait;
+
+    /**
+     * @var \Gotea\Model\Entity\Country
+     */
+    private Country $country;
+
+    /**
+     * Constructor
+     *
+     * @param \Gotea\Model\Entity\Country $country 所属国
+     */
+    public function __construct(Country $country)
+    {
+        $this->country = $country;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPlayers(HttpClient $client, array $ranks): array
+    {
+        $results = [];
+        $rank = null;
+        $crawler = $this->getCrawler(Configure::read('App.diffUrl.taiwan'));
+        $crawler->filter('.post-body.entry-content div:first-child > div')
+            ->each(function (Crawler $node) use (&$results, &$rank, $ranks): void {
+                // テキストが設定されている場合のみ処理する
+                $text = trim($node->text());
+                if ($text) {
+                    $matches = [];
+                    if (preg_match('/(.*段).*\(\d+\)/', $text, $matches)) {
+                        $rank = Hash::get($ranks, $matches[1]);
+                    } else {
+                        $players = Hash::filter($node->filter('a')->each(function ($node) {
+                            return trim(preg_replace("/\s+/u", '', $node->text()));
+                        }), function ($name) {
+                            return !empty($name);
+                        });
+                        if ($players) {
+                            $results[$rank] = Hash::merge(Hash::get($results, $rank, []), $players);
+                        }
+                    }
+                }
+            });
+
+        return $results;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRankSummary(): ResultSetInterface
+    {
+        /** @var \Gotea\Model\Table\OrganizationsTable $organizations */
+        $organizations = TableRegistry::getTableLocator()->get('Organizations');
+
+        // 台湾の場合は台湾棋院のみを対象とする
+        $organization = $organizations->findByName('台湾棋院')->first();
+
+        /** @var \Gotea\Model\Table\PlayersTable $players */
+        $players = TableRegistry::getTableLocator()->get('Players');
+
+        return $players->findRanksCount($this->country->id, $organization->id)->all();
+    }
+}

--- a/src/Command/SubCommand/RankDiffTrait.php
+++ b/src/Command/SubCommand/RankDiffTrait.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Command\SubCommand;
+
+use Cake\Http\Exception\HttpException;
+use Goutte\Client;
+use Symfony\Component\DomCrawler\Crawler;
+
+trait RankDiffTrait
+{
+    /**
+     * URLからCrawlerオブジェクトを返却
+     *
+     * @param string $url URL
+     * @return \Symfony\Component\DomCrawler\Crawler
+     * @throws \Cake\Http\Exception\HttpException
+     */
+    private function getCrawler(string $url): Crawler
+    {
+        $client = new Client();
+
+        $crawler = $client->request('GET', $url);
+        if ($client->getInternalResponse()->getStatusCode() >= 400) {
+            throw new HttpException(
+                'クロール先のページが意図しないレスポンスを返しました。',
+                $client->getInternalResponse()->getStatusCode()
+            );
+        }
+
+        return $crawler;
+    }
+}


### PR DESCRIPTION
### 概要

- 件名のとおり

### 対応内容

- 棋士情報を取得するサブコマンドインターフェースを用意し、所属国ごとに継承してサブコマンド化した