### PR TITLE
段位差分バッチのエラー修正

### DIFF
--- a/src/Command/RankDiffCommand.php
+++ b/src/Command/RankDiffCommand.php
@@ -124,7 +124,7 @@ class RankDiffCommand extends Command
     {
         return $subCommand->getRankSummary()
             ->map(function ($item) use ($results) {
-                $item->web_count = count($results[$item->rank]) ?? 0;
+                $item->web_count = count($results[$item->rank_numeric]) ?? 0;
 
                 return $item;
             })->filter(function ($item) {


### PR DESCRIPTION
### 概要

- rank ではなく rank_numeric を参照するよう修正

### 対応内容

- 
