### PR TITLE
棋士名取得時のセレクタを修正

### DIFF
--- a/src/Command/SubCommand/RankDiffJapanSubCommand.php
+++ b/src/Command/SubCommand/RankDiffJapanSubCommand.php
@@ -121,7 +121,7 @@ class RankDiffJapanSubCommand implements RankDiffSubCommandInterface
             $rankText = $node->text();
             $rank = Hash::get($ranks, $rankText);
             $players = $node->nextAll()->filter('.ul_players')->first()
-                ->filter('li')->each(function (Crawler $cell) {
+                ->filter('li a')->each(function (Crawler $cell) {
                     return $cell->text();
                 });
 


### PR DESCRIPTION
### 概要

- li 内に棋士名以外のセレクタが設定されるケースがあるため、li 下の a からテキストを取得するよう修正

### 対応内容

- 
