### PR TITLE
symfony/css-selector 再インストール

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "connehito/cake-sentry": "^4.0",
     "dereuromark/cakephp-shim": "^2.0",
     "mobiledetect/mobiledetectlib": "^3.74",
-    "symfony/browser-kit": "^6.2",
-    "symfony/css-selector": "^6.2",
-    "symfony/http-client": "^6.1",
+    "symfony/browser-kit": "^6.2.7",
+    "symfony/css-selector": "^6.2.7",
+    "symfony/http-client": "^6.2.7",
     "vlucas/phpdotenv": "^5.4"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5aaa06143362d8e20a80820eafbc60d",
+    "content-hash": "61c0aa32753f64016a1b22b38d81bf62",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -8253,7 +8253,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "psy/psysh": 0
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
### 概要

- すでに vendor ディレクトリが存在する場合にインストールに失敗したため

### 対応内容

- 
