### PR TITLE
fix: enforce SSH host key checking in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,11 @@ jobs:
           name: id_rsa-target
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           config: |
-            Host *
-              StrictHostKeyChecking no
-              UserKnownHostsFile=/dev/null
             Host target
               HostName ${{ secrets.SSH_HOST }}
               User ${{ secrets.SSH_USER }}
               Port ${{ secrets.SSH_PORT }}
+              StrictHostKeyChecking yes
               IdentityFile ~/.ssh/id_rsa-target
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
### 概要

- デプロイ workflow の SSH 接続でホスト鍵検証を無効化していたため、検証を必須化します。

### 対応内容

- `.github/workflows/deploy.yml` から `Host *` の `StrictHostKeyChecking no` と `UserKnownHostsFile=/dev/null` を削除
- `Host target` に `StrictHostKeyChecking yes` を追加
- `known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}` を利用したホスト鍵検証を有効なまま維持