### PR TITLE
CakePHP非推奨警告の解消（認証設定・paginate対応）

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -353,12 +353,12 @@ return [
     'Log' => $debug && PHP_SAPI !== 'cli' ? [
         'debug' => [
             'className' => ConsoleLog::class,
-            'scopes' => false,
+            'scopes' => null,
             'levels' => ['notice', 'info', 'debug'],
         ],
         'error' => [
             'className' => ConsoleLog::class,
-            'scopes' => false,
+            'scopes' => null,
             'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
         ],
         // To enable this dedicated query log, you need set your datasource's log flag to true
@@ -374,7 +374,7 @@ return [
             'size' => '5MB',
             'rotate' => 7,
             'url' => env('LOG_DEBUG_URL', null),
-            'scopes' => false,
+            'scopes' => null,
             'levels' => ['notice', 'info'],
         ],
         'error' => [
@@ -384,7 +384,7 @@ return [
             'size' => '5MB',
             'rotate' => 7,
             'url' => env('LOG_ERROR_URL', null),
-            'scopes' => false,
+            'scopes' => null,
             'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
         ],
     ],

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -49,6 +49,7 @@ use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
 use Dotenv\Repository\Adapter\PutenvAdapter;
 use Dotenv\Repository\RepositoryBuilder;
+use Detection\MobileDetect;
 use function Cake\Core\env;
 
 /*
@@ -179,12 +180,12 @@ Security::setSalt(Configure::consume('Security.salt'));
  * Setup detectors for mobile and tablet.
  */
 ServerRequest::addDetector('mobile', function ($request) {
-    $detector = new \Detection\MobileDetect();
+    $detector = new MobileDetect();
 
     return $detector->isMobile();
 });
 ServerRequest::addDetector('tablet', function ($request) {
-    $detector = new \Detection\MobileDetect();
+    $detector = new MobileDetect();
 
     return $detector->isTablet();
 });

--- a/src/Application.php
+++ b/src/Application.php
@@ -136,26 +136,32 @@ class Application extends BaseApplication implements
      */
     public function getAuthenticationService(ServerRequestInterface $request): AuthenticationServiceInterface
     {
-        $service = new AuthenticationService([
-            'unauthenticatedRedirect' => '/',
-            'queryParam' => 'redirect',
-        ]);
-
         $fields = [
             'username' => 'account',
             'password' => 'password',
         ];
+        $identifier = [
+            'Authentication.Password' => [
+                'fields' => $fields,
+            ],
+        ];
 
-        // Load identifiers
-        $service->identifiers()->load('Authentication.Password', [
-            'fields' => $fields,
-        ]);
-
-        // Load the authenticators, you want session first
-        $service->loadAuthenticator('Gotea.Session');
-        $service->loadAuthenticator('Authentication.Form', [
-            'fields' => $fields,
-            'loginUrl' => '/login',
+        $service = new AuthenticationService([
+            'unauthenticatedRedirect' => '/',
+            'queryParam' => 'redirect',
+            'authenticators' => [
+                'Gotea.Session' => [
+                    'fields' => [
+                        'username' => 'account',
+                    ],
+                    'identifier' => $identifier,
+                ],
+                'Authentication.Form' => [
+                    'fields' => $fields,
+                    'loginUrl' => '/login',
+                    'identifier' => $identifier,
+                ],
+            ],
         ]);
 
         return $service;

--- a/src/Controller/Api/NotificationsController.php
+++ b/src/Controller/Api/NotificationsController.php
@@ -9,7 +9,7 @@ use Cake\Http\Response;
  * Notifications Controller
  *
  * @property \Gotea\Model\Table\NotificationsTable $Notifications
- * @method \Gotea\Model\Entity\Notification[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\Paging\PaginatedInterface paginate($object = null, array $settings = [])
  */
 class NotificationsController extends ApiController
 {
@@ -20,14 +20,14 @@ class NotificationsController extends ApiController
      */
     public function index(): Response
     {
-        $query = $this->Notifications->find()->orderDesc('published');
+        $query = $this->Notifications->find()->orderByDesc('published');
         $notifications = $this->paginate($query);
 
         return $this->renderJson([
             'total' => $query->count(),
-            'items' => $notifications->map(function ($item) {
+            'items' => collection($notifications->items())->map(function ($item) {
                 return $item->toArray();
-            }),
+            })->toList(),
         ]);
     }
 
@@ -39,9 +39,7 @@ class NotificationsController extends ApiController
      */
     public function view(int $id): Response
     {
-        $notification = $this->Notifications->get($id, [
-            'contain' => [],
-        ]);
+        $notification = $this->Notifications->get($id);
 
         return $this->renderJson($notification->toArray());
     }

--- a/src/Controller/Api/RetentionHistoriesController.php
+++ b/src/Controller/Api/RetentionHistoriesController.php
@@ -21,9 +21,7 @@ class RetentionHistoriesController extends ApiController
     public function view(int $id): Response
     {
         /** @var \Gotea\Model\Entity\RetentionHistory $history */
-        $history = $this->RetentionHistories->get($id, [
-            'contain' => ['Players', 'Players.PlayerRanks.Ranks'],
-        ]);
+        $history = $this->RetentionHistories->get($id, contain: ['Players', 'Players.PlayerRanks.Ranks']);
 
         return $this->renderJson([
             'id' => $history->id,

--- a/src/Controller/Api/TableTemplatesController.php
+++ b/src/Controller/Api/TableTemplatesController.php
@@ -9,7 +9,7 @@ use Cake\Http\Response;
  * TableTemplates Controller
  *
  * @property \Gotea\Model\Table\TableTemplatesTable $TableTemplates
- * @method \Gotea\Model\Entity\TableTemplate[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\Paging\PaginatedInterface paginate($object = null, array $settings = [])
  */
 class TableTemplatesController extends ApiController
 {
@@ -20,14 +20,14 @@ class TableTemplatesController extends ApiController
      */
     public function index(): Response
     {
-        $query = $this->TableTemplates->find()->orderAsc('title');
+        $query = $this->TableTemplates->find()->orderBy('title');
         $tableTemplates = $this->paginate($query);
 
         return $this->renderJson([
             'total' => $query->count(),
-            'items' => $tableTemplates->map(function ($item) {
+            'items' => collection($tableTemplates->items())->map(function ($item) {
                 return $item->toArray();
-            }),
+            })->toList(),
         ]);
     }
 }

--- a/src/Controller/NotificationsController.php
+++ b/src/Controller/NotificationsController.php
@@ -16,7 +16,7 @@ use Gotea\Model\Entity\Notification;
  * Notifications Controller
  *
  * @property \Gotea\Model\Table\NotificationsTable $Notifications
- * @method \Gotea\Model\Entity\Notification[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\Paging\PaginatedInterface paginate($object = null, array $settings = [])
  */
 class NotificationsController extends AppController
 {
@@ -76,9 +76,7 @@ class NotificationsController extends AppController
      */
     public function edit(int $id): ?Response
     {
-        $notification = $this->Notifications->get($id, [
-            'contain' => [],
-        ]);
+        $notification = $this->Notifications->get($id);
 
         $this->set('notification', $notification);
 

--- a/src/Controller/TableTemplatesController.php
+++ b/src/Controller/TableTemplatesController.php
@@ -10,7 +10,7 @@ use Cake\Http\Response;
  * Notifications Controller
  *
  * @property \Gotea\Model\Table\TableTemplatesTable $TableTemplates
- * @method \Gotea\Model\Entity\TableTemplate[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\Paging\PaginatedInterface paginate($object = null, array $settings = [])
  */
 class TableTemplatesController extends AppController
 {
@@ -57,9 +57,7 @@ class TableTemplatesController extends AppController
      */
     public function edit(int $id): ?Response
     {
-        $tableTemplate = $this->TableTemplates->get($id, [
-            'contain' => [],
-        ]);
+        $tableTemplate = $this->TableTemplates->get($id);
 
         $this->set('tableTemplate', $tableTemplate);
 

--- a/src/Controller/TitleScoresController.php
+++ b/src/Controller/TitleScoresController.php
@@ -99,9 +99,7 @@ class TitleScoresController extends AppController
      */
     public function searchByPlayer(int $id, int $year): ?Response
     {
-        $player = $this->Players->get($id, [
-            'contain' => 'Ranks',
-        ]);
+        $player = $this->Players->get($id, contain: ['Ranks']);
         $titleScores = $this->TitleScores->findMatches([
             'player_id' => $id,
             'target_year' => $year,
@@ -280,9 +278,7 @@ class TitleScoresController extends AppController
      */
     public function delete(int $id): ?Response
     {
-        $model = $this->TitleScores->get($id, [
-            'contain' => 'TitleScoreDetails',
-        ]);
+        $model = $this->TitleScores->get($id, contain: ['TitleScoreDetails']);
 
         foreach ($model->title_score_details as $detail) {
             $this->TitleScoreDetails->delete($detail);
@@ -305,9 +301,7 @@ class TitleScoresController extends AppController
      */
     private function switchDivision(int $id): ?Response
     {
-        $score = $this->TitleScores->get($id, [
-            'contain' => 'TitleScoreDetails',
-        ]);
+        $score = $this->TitleScores->get($id, contain: ['TitleScoreDetails']);
 
         $changed = 0;
         foreach ($score->title_score_details as $detail) {

--- a/src/Model/Table/NotificationsTable.php
+++ b/src/Model/Table/NotificationsTable.php
@@ -85,6 +85,6 @@ class NotificationsTable extends AppTable
     public function findAllNewestArrivals(): Query
     {
         // 棋士情報の取得
-        return $this->find()->orderDesc('published');
+        return $this->find()->orderByDesc('published');
     }
 }

--- a/src/Model/Table/OrganizationsTable.php
+++ b/src/Model/Table/OrganizationsTable.php
@@ -39,6 +39,6 @@ class OrganizationsTable extends AppTable
      */
     public function findSorted(): Query
     {
-        return $this->find('list')->order(['country_id', 'id']);
+        return $this->find('list')->orderBy(['country_id', 'id']);
     }
 }

--- a/src/Model/Table/PlayerRanksTable.php
+++ b/src/Model/Table/PlayerRanksTable.php
@@ -105,7 +105,7 @@ class PlayerRanksTable extends AppTable
     public function findRanks(int $playerId): ResultSet
     {
         return $this->findByPlayerId($playerId)
-            ->contain(['Ranks'])->orderDesc('Ranks.rank_numeric')->all();
+            ->contain(['Ranks'])->orderByDesc('Ranks.rank_numeric')->all();
     }
 
     /**
@@ -124,8 +124,8 @@ class PlayerRanksTable extends AppTable
                 },
             ])
             ->where(['PlayerRanks.promoted >=' => FrozenDate::now()->addMonths(-2)])
-            ->orderDesc('PlayerRanks.promoted')
-            ->order('Players.country_id')
-            ->orderDesc('Ranks.rank_numeric');
+            ->orderByDesc('PlayerRanks.promoted')
+            ->orderBy('Players.country_id')
+            ->orderByDesc('Ranks.rank_numeric');
     }
 }

--- a/src/Model/Table/PlayerScoresTable.php
+++ b/src/Model/Table/PlayerScoresTable.php
@@ -46,7 +46,7 @@ class PlayerScoresTable extends AppTable
     public function findDescYears(int $playerId): ResultSet
     {
         return $this->findByPlayerId($playerId)
-            ->contain(['Ranks'])->orderDesc('target_year')->all();
+            ->contain(['Ranks'])->orderByDesc('target_year')->all();
     }
 
     /**
@@ -80,11 +80,11 @@ class PlayerScoresTable extends AppTable
                 ]);
 
         if ($isPercent) {
-            $subQuery->orderDesc('win_percent');
+            $subQuery->orderByDesc('win_percent');
         }
 
-        $subQuery->orderDesc($winColumn)
-            ->order($loseColumn)
+        $subQuery->orderByDesc($winColumn)
+            ->orderBy($loseColumn)
             ->limit(1)->offset($offset - 1);
 
         if ($country->has_title) {
@@ -112,17 +112,17 @@ class PlayerScoresTable extends AppTable
         if ($isPercent) {
             $query->having(function ($exp, $q) use ($subQuery) {
                 return $exp->gte('win_percent', $subQuery);
-            })->orderDesc('win_percent');
+            })->orderByDesc('win_percent');
         } else {
             $query->where(function ($exp, $q) use ($winColumn, $subQuery) {
                 return $exp->gte($winColumn, $subQuery);
             });
         }
 
-        $query->orderDesc($winColumn)
-            ->order($loseColumn)
-            ->orderDesc('Ranks.rank_numeric')
-            ->order('Players.joined');
+        $query->orderByDesc($winColumn)
+            ->orderBy($loseColumn)
+            ->orderByDesc('Ranks.rank_numeric')
+            ->orderBy('Players.joined');
 
         if (!$country->isWorlds()) {
             $query->where(['country_id' => $country->id]);

--- a/src/Model/Table/PlayersTable.php
+++ b/src/Model/Table/PlayersTable.php
@@ -134,7 +134,7 @@ class PlayersTable extends AppTable
     public function findPlayers(array $data): Query
     {
         // 棋士情報の取得
-        $query = $this->find()->order([
+        $query = $this->find()->orderBy([
             'Ranks.rank_numeric DESC', 'Players.joined', 'Players.id',
         ])->contain([
             'Ranks', 'Countries', 'Organizations', 'TitleScoreDetails',
@@ -202,9 +202,9 @@ class PlayersTable extends AppTable
         $direction = Hash::get($data, 'direction', 'asc');
         if ($sort && in_array(strtolower($sort), $fields, true)) {
             if (in_array(strtolower($direction), ['asc', 'desc'], true)) {
-                $query->order(["Players.{$sort}" => $direction], true);
+                $query->orderBy(["Players.{$sort}" => $direction], true);
             } else {
-                $query->order(["Players.{$sort}" => 'asc'], true);
+                $query->orderBy(["Players.{$sort}" => 'asc'], true);
             }
         }
 
@@ -240,8 +240,8 @@ class PlayersTable extends AppTable
                 'name' => 'Ranks.name',
                 'count' => $query->func()->count('*'),
             ])
-            ->group(['Ranks.id', 'Ranks.rank_numeric', 'Ranks.name'])
-            ->orderDesc('Ranks.rank_numeric');
+            ->groupBy(['Ranks.id', 'Ranks.rank_numeric', 'Ranks.name'])
+            ->orderByDesc('Ranks.rank_numeric');
     }
 
     /**

--- a/src/Model/Table/RanksTable.php
+++ b/src/Model/Table/RanksTable.php
@@ -27,7 +27,7 @@ class RanksTable extends AppTable
     public function findProfessional(): Query
     {
         return $this->find()->whereNotNull('rank_numeric')
-            ->orderDesc('rank_numeric')->select(['id', 'name', 'rank_numeric']);
+            ->orderByDesc('rank_numeric')->select(['id', 'name', 'rank_numeric']);
     }
 
     /**

--- a/src/Model/Table/RetentionHistoriesTable.php
+++ b/src/Model/Table/RetentionHistoriesTable.php
@@ -152,7 +152,7 @@ class RetentionHistoriesTable extends AppTable
     {
         return $this->findByPlayerId($playerId)
             ->contain(['Titles.Countries'])
-            ->order([
+            ->orderBy([
                 'RetentionHistories.target_year' => 'DESC',
                 'Titles.country_id' => 'ASC',
                 'RetentionHistories.acquired' => 'ASC',
@@ -169,7 +169,7 @@ class RetentionHistoriesTable extends AppTable
     {
         return $this->findByTitleId($titleId)
             ->contain(['Titles'])
-            ->order([
+            ->orderBy([
                 'RetentionHistories.target_year' => 'DESC',
             ]);
     }

--- a/src/Model/Table/TitleScoreDetailsTable.php
+++ b/src/Model/Table/TitleScoreDetailsTable.php
@@ -109,7 +109,7 @@ class TitleScoreDetailsTable extends AppTable
             'win_point_all' => $query->func()->count("division = '勝' or null"),
             'lose_point_all' => $query->func()->count("division = '敗' or null"),
             'draw_point_all' => $query->func()->count("division = '分' or null"),
-        ])->group([
+        ])->groupBy([
                     'player_id',
                     'target_year',
                 ]);
@@ -174,7 +174,7 @@ class TitleScoreDetailsTable extends AppTable
             ->from(['TitleScoreDetails' => $standardQuery])
             ->select(['value' => $selectFields])
             ->having(['value >' => 0])
-            ->orderDesc('value')
+            ->orderByDesc('value')
             ->limit(1)
             ->offset($limit - 1)
             ->first();
@@ -205,7 +205,7 @@ class TitleScoreDetailsTable extends AppTable
                 'Players.PlayerRanks' => function ($q) use ($ended) {
                     // 抽出期間TOよりも前の段位を取得
                     return $q->where(['PlayerRanks.promoted <=' => $ended])
-                        ->orderDesc('PlayerRanks.promoted');
+                        ->orderByDesc('PlayerRanks.promoted');
                 },
                 'Players.PlayerRanks.Ranks' => function ($q) {
                     // 昇段情報が不足しているケースがあるため、初段は含めない
@@ -225,7 +225,7 @@ class TitleScoreDetailsTable extends AppTable
             ->select($this->Players->Ranks);
 
         if ($type === 'percent') {
-            $query->orderDesc('win_percent');
+            $query->orderByDesc('win_percent');
             if ($value !== null) {
                 $query->having(['win_percent >=' => $value->value]);
             } else {
@@ -240,10 +240,10 @@ class TitleScoreDetailsTable extends AppTable
         }
 
         return $query
-            ->orderDesc('win_point')
-            ->order(['lose_point'])
-            ->orderDesc('Ranks.rank_numeric')
-            ->order(['Players.joined']);
+            ->orderByDesc('win_point')
+            ->orderBy(['lose_point'])
+            ->orderByDesc('Ranks.rank_numeric')
+            ->orderBy(['Players.joined']);
     }
 
     /**

--- a/src/Model/Table/TitleScoresTable.php
+++ b/src/Model/Table/TitleScoresTable.php
@@ -138,7 +138,7 @@ class TitleScoresTable extends AppTable
                 'TitleScoreDetails.Players.Ranks',
                 'TitleScoreDetails.Players.PlayerRanks.Ranks',
             ])
-            ->orderDesc('started')->orderDesc('TitleScores.id');
+            ->orderByDesc('started')->orderByDesc('TitleScores.id');
 
         $id = Hash::get($data, 'player_id');
         if ($id) {
@@ -161,7 +161,7 @@ class TitleScoresTable extends AppTable
                         'player_names' => $query->func()->group_concat([
                             'player_name separator \'/\'' => 'identifier',
                         ]),
-                    ])->group('title_score_id')->having([
+                    ])->groupBy('title_score_id')->having([
                         'OR' => [
                             ["player_names LIKE '%{$name1}%/%{$name2}%'"],
                             ["player_names LIKE '%{$name2}%/%{$name1}%'"],

--- a/src/Model/Table/TitlesTable.php
+++ b/src/Model/Table/TitlesTable.php
@@ -137,14 +137,12 @@ class TitlesTable extends AppTable
      */
     public function findByIdWithRelation(int $id): Title
     {
-        return $this->get($id, [
-            'contain' => [
-                'Countries',
-                'RetentionHistories',
-                'RetentionHistories.Players',
-                'RetentionHistories.Players.PlayerRanks.Ranks',
-                'RetentionHistories.Countries',
-            ],
+        return $this->get($id, contain: [
+            'Countries',
+            'RetentionHistories',
+            'RetentionHistories.Players',
+            'RetentionHistories.Players.PlayerRanks.Ranks',
+            'RetentionHistories.Countries',
         ]);
     }
 
@@ -155,7 +153,7 @@ class TitlesTable extends AppTable
      */
     public function findSortedList(): Query
     {
-        return $this->find('list')->order(['country_id', 'id']);
+        return $this->find('list')->orderBy(['country_id', 'id']);
     }
 
     /**
@@ -194,7 +192,7 @@ class TitlesTable extends AppTable
         }
 
         // データを取得
-        return $query->order(['Titles.country_id', 'Titles.is_closed', 'Titles.sort_order']);
+        return $query->orderBy(['Titles.country_id', 'Titles.is_closed', 'Titles.sort_order']);
     }
 
     /**

--- a/tests/TestCase/Model/Table/PlayerRanksTableTest.php
+++ b/tests/TestCase/Model/Table/PlayerRanksTableTest.php
@@ -137,9 +137,7 @@ class PlayerRanksTableTest extends TestCase
         $this->assertNotEquals(false, $save);
 
         // 棋士情報の段位とは一致しない
-        $saveRank = $this->PlayerRanks->get($save->id, [
-            'contain' => 'Players',
-        ]);
+        $saveRank = $this->PlayerRanks->get($save->id, contain: ['Players']);
         $this->assertNotEquals($saveRank->rank_id, $saveRank->player->rank_id);
 
         // 最新として登録
@@ -156,9 +154,7 @@ class PlayerRanksTableTest extends TestCase
         $this->assertNotEquals(false, $save);
 
         // 棋士情報の段位と一致
-        $saveRank = $this->PlayerRanks->get($save->id, [
-            'contain' => 'Players',
-        ]);
+        $saveRank = $this->PlayerRanks->get($save->id, contain: ['Players']);
         $this->assertEquals($saveRank->rank_id, $saveRank->player->rank_id);
     }
 


### PR DESCRIPTION
## 概要
CakePHP の非推奨警告対応として、認証設定と paginated result の扱いを更新しました。

## 変更内容
- AuthenticationService のトップレベル identifiers 依存を廃止
- Gotea.Session / Authentication.Form の各 authenticator に identifier を直接設定
- PaginatedResultSet の map() 直接呼び出しを廃止
- items() 経由で collection(...)->map(...)->toList() に変更
- paginate() の PHPDoc 型を Cake\\Datasource\\Paging\\PaginatedInterface に更新
- 一部クエリメソッドを現行 API へ更新（orderBy*, groupBy, contain）

## 確認
- 対象ファイルの php -l を実行し、構文エラーがないことを確認済みです。
