### PR TITLE
APIレスポンスのContent-TypeをJSONに修正し、APIテストで検証を追加

### DIFF
--- a/src/Controller/JsonResponseTrait.php
+++ b/src/Controller/JsonResponseTrait.php
@@ -53,7 +53,9 @@ trait JsonResponseTrait
      */
     public function renderJson(array|JsonSerializable $json = []): Response
     {
-        return $this->response->withStringBody(json_encode([
+        return $this->getResponse()
+            ->withType('json')
+            ->withStringBody(json_encode([
             'response' => $json,
             // '_serialize' => true,
         ]));

--- a/tests/TestCase/Controller/Api/ApiTestCase.php
+++ b/tests/TestCase/Controller/Api/ApiTestCase.php
@@ -71,4 +71,14 @@ abstract class ApiTestCase extends AppTestCase
     {
         return json_encode($data);
     }
+
+    /**
+     * レスポンスがJSONで返却されることを確認します。
+     *
+     * @return void
+     */
+    protected function assertJsonContentType()
+    {
+        $this->assertContentType('application/json');
+    }
 }

--- a/tests/TestCase/Controller/Api/NotificationsControllerTest.php
+++ b/tests/TestCase/Controller/Api/NotificationsControllerTest.php
@@ -37,6 +37,7 @@ class NotificationsControllerTest extends ApiTestCase
     {
         $this->get('/api/notifications?limit=2');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertNotEquals($this->getEmptyResponse(), $this->_getBodyAsString());
         $response = json_decode($this->_getBodyAsString())->response;
         $this->assertEquals($response->total, 5);

--- a/tests/TestCase/Controller/Api/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/Api/PlayersControllerTest.php
@@ -57,6 +57,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->get('/api/players/ranks/999');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertResponseEquals($this->getEmptyResponse());
     }
 
@@ -69,6 +70,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->get('/api/players/ranks/1');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertResponseNotEquals($this->getEmptyResponse());
     }
 
@@ -82,6 +84,7 @@ class PlayersControllerTest extends ApiTestCase
         // 所属国
         $this->get('/api/players/ranking/testtest/2017/20');
         $this->assertResponseCode(404);
+        $this->assertJsonContentType();
         $this->assertResponseEquals($this->getNotFoundResponse());
     }
 
@@ -118,6 +121,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->get('/api/players/ranking/jp/2000/20');
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $this->assertResponseEquals($this->getCompareJsonResponse([
             'response' => [
                 'countryCode' => 'jp',
@@ -139,6 +143,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->get('/api/players/ranking/jp/2017/20');
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $this->assertResponseNotEquals($this->getCompareJsonResponse([
             'response' => [
                 'countryCode' => 'jp',
@@ -169,6 +174,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->get('/api/players/ranking/jp/2017/20?type=point');
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $data = json_decode($this->_getBodyAsString())->response->ranking;
         $this->assertGreaterThan(0, count($data));
         collection($data)->each(function ($item, $idx) use ($data) {
@@ -188,6 +194,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->get('/api/players/ranking/jp/2017/20?type=percent');
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $data = json_decode($this->_getBodyAsString())->response->ranking;
         $this->assertGreaterThan(0, count($data));
         collection($data)->each(function ($item, $idx) use ($data) {
@@ -210,6 +217,7 @@ class PlayersControllerTest extends ApiTestCase
         $fromValue = $targetFrom->i18nFormat('yyyy-MM-dd');
         $this->get("/api/players/ranking/jp/2017/20?from={$fromValue}");
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $lastUpdate = FrozenDate::parseDate(
             Hash::get($this->getResponseArray(), 'response.lastUpdate'),
             'yyyy-MM-dd',
@@ -229,6 +237,7 @@ class PlayersControllerTest extends ApiTestCase
         $toValue = $targetTo->i18nFormat('yyyy-MM-dd');
         $this->get("/api/players/ranking/jp/2017/20?to={$toValue}");
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $lastUpdate = FrozenDate::parseDate(
             Hash::get($this->getResponseArray(), 'response.lastUpdate'),
             'yyyy-MM-dd',
@@ -250,6 +259,7 @@ class PlayersControllerTest extends ApiTestCase
         $toValue = $targetTo->i18nFormat('yyyy-MM-dd');
         $this->get("/api/players/ranking/jp/2017/20?from={$fromValue}&to={$toValue}");
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $lastUpdate = FrozenDate::parseDate(
             Hash::get($this->getResponseArray(), 'response.lastUpdate'),
             'yyyy-MM-dd',
@@ -268,6 +278,7 @@ class PlayersControllerTest extends ApiTestCase
         // 所属国
         $this->post('/api/players/ranking/testtest/2017/20');
         $this->assertResponseCode(404);
+        $this->assertJsonContentType();
         $this->assertResponseEquals($this->getNotFoundResponse());
     }
 
@@ -304,6 +315,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->post('/api/players/ranking/jp/2000/20');
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $this->assertResponseEquals($this->getCompareJsonResponse([
             'response' => [
                 'countryCode' => 'jp',
@@ -325,6 +337,7 @@ class PlayersControllerTest extends ApiTestCase
     {
         $this->post('/api/players/ranking/jp/2017/20');
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $this->assertResponseNotEquals($this->getCompareJsonResponse([
             'response' => [
                 'countryCode' => 'jp',
@@ -358,6 +371,7 @@ class PlayersControllerTest extends ApiTestCase
             'from' => $targetFrom->i18nFormat('yyyy-MM-dd'),
         ]);
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $lastUpdate = FrozenDate::parseDate(
             Hash::get($this->getResponseArray(), 'response.lastUpdate'),
             'yyyy-MM-dd',
@@ -378,6 +392,7 @@ class PlayersControllerTest extends ApiTestCase
             'to' => $targetTo->i18nFormat('yyyy-MM-dd'),
         ]);
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $lastUpdate = FrozenDate::parseDate(
             Hash::get($this->getResponseArray(), 'response.lastUpdate'),
             'yyyy-MM-dd',
@@ -400,6 +415,7 @@ class PlayersControllerTest extends ApiTestCase
             'to' => $targetTo->i18nFormat('yyyy-MM-dd'),
         ]);
         $this->assertResponseCode(200);
+        $this->assertJsonContentType();
         $lastUpdate = FrozenDate::parseDate(
             Hash::get($this->getResponseArray(), 'response.lastUpdate'),
             'yyyy-MM-dd',

--- a/tests/TestCase/Controller/Api/RanksControllerTest.php
+++ b/tests/TestCase/Controller/Api/RanksControllerTest.php
@@ -39,5 +39,6 @@ class RanksControllerTest extends ApiTestCase
     {
         $this->get(['_name' => 'api_ranks']);
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
     }
 }

--- a/tests/TestCase/Controller/Api/TableTemplatesControllerTest.php
+++ b/tests/TestCase/Controller/Api/TableTemplatesControllerTest.php
@@ -37,6 +37,7 @@ class TableTemplatesControllerTest extends ApiTestCase
     {
         $this->get('/api/table-templates?limit=1');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertNotEquals($this->getEmptyResponse(), $this->_getBodyAsString());
         $response = json_decode($this->_getBodyAsString())->response;
         $this->assertEquals($response->total, 2);

--- a/tests/TestCase/Controller/Api/TitlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/TitlesControllerTest.php
@@ -40,6 +40,7 @@ class TitlesControllerTest extends ApiTestCase
     {
         $this->get('/api/titles?country_id=1');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertNotEquals($this->getEmptyResponse(), $this->_getBodyAsString());
         collection(json_decode($this->_getBodyAsString())->response)->each(function ($item) {
             $this->assertEquals($item->countryId, 1);
@@ -56,6 +57,7 @@ class TitlesControllerTest extends ApiTestCase
     {
         $this->get('/api/titles?search_non_output=1');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertNotEquals($this->getEmptyResponse(), $this->_getBodyAsString());
         collection(json_decode($this->_getBodyAsString())->response)->each(function ($item) {
             $this->assertTrue(in_array($item->isOutput, [true, false], true));
@@ -71,6 +73,7 @@ class TitlesControllerTest extends ApiTestCase
     {
         $this->get('/api/titles?search_closed=1');
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
         $this->assertNotEquals($this->getEmptyResponse(), $this->_getBodyAsString());
         collection(json_decode($this->_getBodyAsString())->response)->each(function ($item) {
             $this->assertTrue(in_array($item->isClosed, [true, false], true));
@@ -90,6 +93,7 @@ class TitlesControllerTest extends ApiTestCase
             'holding' => 1,
         ]);
         $this->assertResponseCode(400);
+        $this->assertJsonContentType();
     }
 
     /**
@@ -109,5 +113,6 @@ class TitlesControllerTest extends ApiTestCase
             'htmlFileModified' => '2018/01/01',
         ]);
         $this->assertResponseSuccess();
+        $this->assertJsonContentType();
     }
 }


### PR DESCRIPTION
## 概要
- `JsonResponseTrait::renderJson()` で `Content-Type: application/json` を明示するよう修正
- API系コントローラテストにJSONレスポンスの `Content-Type` アサーションを追加
- APIテスト共通の `assertJsonContentType()` ヘルパーを追加

## 変更ファイル
- `src/Controller/JsonResponseTrait.php`
- `tests/TestCase/Controller/Api/ApiTestCase.php`
- `tests/TestCase/Controller/Api/PlayersControllerTest.php`
- `tests/TestCase/Controller/Api/RanksControllerTest.php`
- `tests/TestCase/Controller/Api/TitlesControllerTest.php`
- `tests/TestCase/Controller/Api/NotificationsControllerTest.php`
- `tests/TestCase/Controller/Api/TableTemplatesControllerTest.php`

## テスト
- `php -l` による変更ファイルの構文チェック: OK
- `vendor/bin/phpunit tests/TestCase/Controller/Api`: ローカル環境のDB接続（`database`ホスト）に失敗し実行不可

## 補足
- 既存の `package-lock.json` のローカル変更は本PRに含めていません。
