### PR TITLE
MariaDB の永続化ボリュームを named volume に変更

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,7 @@ services:
   database:
     image: mariadb:10.5
     volumes:
-      - ./database:/var/lib/mysql
+      - db:/var/lib/mysql
       - ./tests:/docker-entrypoint-initdb.d:ro
     environment:
       MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes'
@@ -36,3 +36,4 @@ services:
 volumes:
   node_modules:
   vendor:
+  db:


### PR DESCRIPTION
## 概要
MariaDB のデータディレクトリを bind mount (`./database`) から named volume (`db`) に変更しました。

## 背景
MySQL 5.7 から MariaDB へ変更後、コンテナ再作成時にデータが初期化される事象が発生していました。
`./database` が安定して参照されず、実質的に一時領域が使われるケースがあり、起動のたびに初期化される状態でした。

## 変更内容
- `compose.yml` の DB マウント先を `db:/var/lib/mysql` に変更
- ルート `volumes` に `db` を追加

## 影響
- DB データは Docker named volume (`gotea_db`) に永続化されます
- 無関係の変更（`package-lock.json`）はこの PR に含めていません