### PR TITLE
ページネーションの履歴管理と状態復元を共通化

### DIFF
--- a/resources/assets/scripts/libs/pagination-url.test.ts
+++ b/resources/assets/scripts/libs/pagination-url.test.ts
@@ -1,0 +1,117 @@
+import {
+  listenPaginationPopState,
+  pushPaginationState,
+  readPaginationFromUrl,
+} from '@/libs/pagination-url';
+
+const setLocation = (href: string) => {
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  // @ts-ignore
+  delete window.location;
+  // @ts-ignore
+  window.location = { href };
+  /* eslint-enable */
+};
+
+describe('pagination-url', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readPaginationFromUrl', () => {
+    test('URL の limit/page を数値として読み取る', () => {
+      setLocation('https://hoge.example.com/notifications?limit=15&page=4');
+
+      expect(readPaginationFromUrl(30)).toStrictEqual({
+        limit: 15,
+        page: 4,
+      });
+    });
+
+    test('不正な値の場合はデフォルト値を返す', () => {
+      setLocation('https://hoge.example.com/notifications?limit=abc&page=-1');
+
+      expect(readPaginationFromUrl(50)).toStrictEqual({
+        limit: 50,
+        page: 1,
+      });
+    });
+  });
+
+  describe('pushPaginationState', () => {
+    test('URL が変わる場合のみ pushState を呼び出す', () => {
+      setLocation('https://hoge.example.com/notifications?limit=10&page=1');
+      const pushStateSpy = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+
+      pushPaginationState({ page: 2, limit: 30 });
+
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+      expect(pushStateSpy).toHaveBeenCalledWith(
+        { page: 2, limit: 30 },
+        '',
+        new URL('https://hoge.example.com/notifications?limit=30&page=2'),
+      );
+    });
+
+    test('URL が同じ場合は pushState を呼び出さない', () => {
+      setLocation('https://hoge.example.com/notifications?limit=30&page=2');
+      const pushStateSpy = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+
+      pushPaginationState({ page: 2, limit: 30 });
+
+      expect(pushStateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listenPaginationPopState', () => {
+    test('popstate 時に URL の値を読み取ってコールバックへ渡す', () => {
+      setLocation('https://hoge.example.com/notifications?limit=10&page=1');
+      const callback = vi.fn();
+      const cleanup = listenPaginationPopState(30, callback);
+
+      setLocation('https://hoge.example.com/notifications?limit=50&page=3');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({ page: 3, limit: 50 });
+      cleanup();
+    });
+
+    test('解除後は popstate でコールバックが呼ばれない', () => {
+      setLocation('https://hoge.example.com/notifications?limit=10&page=1');
+      const callback = vi.fn();
+      const cleanup = listenPaginationPopState(30, callback);
+
+      cleanup();
+      setLocation('https://hoge.example.com/notifications?limit=20&page=2');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    test('pageshow 時にも URL の値を読み取ってコールバックへ渡す', () => {
+      setLocation('https://hoge.example.com/notifications?limit=10&page=1');
+      const callback = vi.fn();
+      const cleanup = listenPaginationPopState(30, callback);
+
+      setLocation('https://hoge.example.com/notifications?limit=25&page=5');
+      window.dispatchEvent(new Event('pageshow'));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({ page: 5, limit: 25 });
+      cleanup();
+    });
+
+    test('解除後は pageshow でコールバックが呼ばれない', () => {
+      setLocation('https://hoge.example.com/notifications?limit=10&page=1');
+      const callback = vi.fn();
+      const cleanup = listenPaginationPopState(30, callback);
+
+      cleanup();
+      setLocation('https://hoge.example.com/notifications?limit=25&page=5');
+      window.dispatchEvent(new Event('pageshow'));
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/resources/assets/scripts/libs/pagination-url.ts
+++ b/resources/assets/scripts/libs/pagination-url.ts
@@ -1,0 +1,43 @@
+import { isPositiveNumber } from '@/libs/validator';
+
+type Pagination = {
+  page: number;
+  limit: number;
+};
+
+export const readPaginationFromUrl = (defaultLimit = 30): Pagination => {
+  const url = new URL(location.href);
+  const limit = url.searchParams.get('limit') || '';
+  const page = url.searchParams.get('page') || '';
+
+  return {
+    limit: isPositiveNumber(limit) ? Number.parseInt(limit, 10) : defaultLimit,
+    page: isPositiveNumber(page) ? Number.parseInt(page, 10) : 1,
+  };
+};
+
+export const pushPaginationState = ({ page, limit }: Pagination): void => {
+  const url = new URL(location.href);
+  url.searchParams.set('limit', limit.toString());
+  url.searchParams.set('page', page.toString());
+
+  if (url.toString() !== location.href) {
+    history.pushState({ page, limit }, '', url);
+  }
+};
+
+export const listenPaginationPopState = (
+  defaultLimit: number,
+  callback: (pagination: Pagination) => void,
+): (() => void) => {
+  const onLocationChanged = () => {
+    callback(readPaginationFromUrl(defaultLimit));
+  };
+  window.addEventListener('popstate', onLocationChanged);
+  window.addEventListener('pageshow', onLocationChanged);
+
+  return () => {
+    window.removeEventListener('popstate', onLocationChanged);
+    window.removeEventListener('pageshow', onLocationChanged);
+  };
+};

--- a/resources/assets/scripts/pages/notifications/index.vue
+++ b/resources/assets/scripts/pages/notifications/index.vue
@@ -39,7 +39,11 @@ import { defineComponent } from 'vue';
 import Paginator from '@/components/Paginator.vue';
 import ListItem from '@/components/notifications/Item.vue';
 import { Notification as Item, NotificationListResponse as Response } from '@/types/notification';
-import { isPositiveNumber } from '@/libs/validator';
+import {
+  listenPaginationPopState,
+  pushPaginationState,
+  readPaginationFromUrl,
+} from '@/libs/pagination-url';
 
 export default defineComponent({
   components: {
@@ -57,18 +61,24 @@ export default defineComponent({
     items: [] as Item[],
     currentPage: 1,
     perPage: 30,
+    cleanupPopStateListener: null as null | (() => void),
   }),
   mounted() {
-    const url = new URL(location.href);
-    const limit = url.searchParams.get('limit');
-    const page = url.searchParams.get('page');
-    if (isPositiveNumber(limit)) {
-      this.perPage = Number.parseInt(limit as string, 10);
-    }
-    if (isPositiveNumber(page)) {
-      this.currentPage = Number.parseInt(page as string, 10);
-    }
+    const { page, limit } = readPaginationFromUrl(this.perPage);
+    this.perPage = limit;
+    this.currentPage = page;
+    this.cleanupPopStateListener = listenPaginationPopState(this.perPage, ({ page, limit }) => {
+      if (this.currentPage === page && this.perPage === limit) {
+        return;
+      }
+      this.perPage = limit;
+      this.onSearch(page);
+    });
     this.onSearch(this.currentPage);
+  },
+  beforeUnmount() {
+    this.cleanupPopStateListener?.();
+    this.cleanupPopStateListener = null;
   },
   methods: {
     onSearch(page: number) {
@@ -79,12 +89,7 @@ export default defineComponent({
         .then(({ response: { total, items } }) => {
           this.total = total;
           this.items = items;
-          const url = new URL(location.href);
-          url.searchParams.set('limit', this.perPage.toString());
-          url.searchParams.set('page', this.currentPage.toString());
-          if (url.toString() !== location.href) {
-            history.replaceState({ page: this.currentPage, limit: this.perPage }, '', url);
-          }
+          pushPaginationState({ page: this.currentPage, limit: this.perPage });
         });
     },
   },

--- a/resources/assets/scripts/pages/table-templates/index.vue
+++ b/resources/assets/scripts/pages/table-templates/index.vue
@@ -40,7 +40,11 @@ import {
   TableTemplate as Item,
   TableTemplateListResponse as Response,
 } from '@/types/table-template';
-import { isPositiveNumber } from '@/libs/validator';
+import {
+  listenPaginationPopState,
+  pushPaginationState,
+  readPaginationFromUrl,
+} from '@/libs/pagination-url';
 
 export default defineComponent({
   components: {
@@ -58,18 +62,24 @@ export default defineComponent({
     items: [] as Item[],
     currentPage: 1,
     perPage: 30,
+    cleanupPopStateListener: null as null | (() => void),
   }),
   mounted() {
-    const url = new URL(location.href);
-    const limit = url.searchParams.get('limit');
-    const page = url.searchParams.get('page');
-    if (isPositiveNumber(limit)) {
-      this.perPage = Number.parseInt(limit as string, 10);
-    }
-    if (isPositiveNumber(page)) {
-      this.currentPage = Number.parseInt(page as string, 10);
-    }
+    const { page, limit } = readPaginationFromUrl(this.perPage);
+    this.perPage = limit;
+    this.currentPage = page;
+    this.cleanupPopStateListener = listenPaginationPopState(this.perPage, ({ page, limit }) => {
+      if (this.currentPage === page && this.perPage === limit) {
+        return;
+      }
+      this.perPage = limit;
+      this.onSearch(page);
+    });
     this.onSearch(this.currentPage);
+  },
+  beforeUnmount() {
+    this.cleanupPopStateListener?.();
+    this.cleanupPopStateListener = null;
   },
   methods: {
     onSearch(page: number) {
@@ -80,12 +90,7 @@ export default defineComponent({
         .then(({ response: { total, items } }) => {
           this.total = total;
           this.items = items;
-          const url = new URL(location.href);
-          url.searchParams.set('limit', this.perPage.toString());
-          url.searchParams.set('page', this.currentPage.toString());
-          if (url.toString() !== location.href) {
-            history.replaceState({ page: this.currentPage, limit: this.perPage }, '', url);
-          }
+          pushPaginationState({ page: this.currentPage, limit: this.perPage });
         });
     },
   },


### PR DESCRIPTION
## 概要
- ページネーションのURLクエリ読み取り・履歴追加を共通ヘルパー化
- notifications / table-templates の一覧ページで共通ヘルパーを利用
- ブラウザの戻る/進むで popstate / pageshow を拾って状態復元
- 共通ヘルパーのユニットテストを追加

## テスト
- npm test -- resources/assets/scripts/libs/pagination-url.test.ts resources/assets/scripts/pages/notifications/index.test.ts resources/assets/scripts/pages/table-templates/index.test.ts

Closes #1408