### PR TITLE
plansディレクトリをgitignore対象に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ mise.toml
 
 # phpunit cache
 .phpunit.result.cache
+
+# local planning notes
+/plans/*
+!/plans/.gitignore

--- a/plans/.gitignore
+++ b/plans/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## 概要
ローカルで利用している実装計画メモ用ディレクトリ `plans/` を Git の追跡対象から除外しました。

## 変更内容
- `.gitignore` に以下を追加
  - `/plans/`

## 目的
- ローカル運用のメモを誤ってコミットしないようにするため
