### PR TITLE
デプロイ時のアーティファクト転送経路を簡素化し後始末を整理

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       PROJECT: '${{ github.event.repository.name }}'
-      TAR_NAME: '${{ github.event.repository.name }}_${{ github.run_number }}.tar.gz'
-      SHELL_DEST_PATH: '~/deploy_${{ github.event.repository.name }}_${{ github.run_number }}.sh'
+      TAR_NAME: '${{ github.run_number }}.tar.gz'
+      TAR_REMOTE_PATH: '~/release/tmp/${{ github.event.repository.name }}/deploy/${{ github.run_number }}.tar.gz'
+      SHELL_DEST_PATH: '~/release/tmp/deploy_${{ github.run_number }}.sh'
       PUBLIC_DIR: '${{ secrets.PUBLIC_DIR }}'
     runs-on: ubuntu-latest
     steps:
@@ -48,11 +49,12 @@ jobs:
               IdentityFile ~/.ssh/id_rsa-target
       - name: Transfer modules
         run: |
+          ssh target "mkdir -p ~/release/tmp/${PROJECT}/deploy"
           tar czf ~/${TAR_NAME} bin/ config/ plugins/ resources/ src/ templates/ webroot/ composer.json composer.lock
-          scp -r ~/${TAR_NAME} target:~/
+          scp ~/${TAR_NAME} target:${TAR_REMOTE_PATH}
           scp ./scripts/deploy.sh target:${SHELL_DEST_PATH}
       - name: Deploy modules
-        run: ssh target "${SHELL_DEST_PATH} ${TAR_NAME} ${PROJECT} ${PUBLIC_DIR} && rm -f ${SHELL_DEST_PATH}"
+        run: ssh target "${SHELL_DEST_PATH} ${TAR_REMOTE_PATH} ${PROJECT} ${PUBLIC_DIR} && rm -f ${SHELL_DEST_PATH}"
 
   notify:
     if: ${{ always() }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <tar_name> <project> <public_dir>" >&2
+  echo "Usage: $0 <tar_path> <project> <public_dir>" >&2
   exit 1
 fi
 
-TAR_NAME="$1"
+TAR_PATH="$1"
 PROJECT="$2"
 PUBLIC_DIR="$3"
 
@@ -23,8 +23,18 @@ CURRENT_PATH="${WORK_DIR}/current"
 TARGET_PATH="${PUBLIC_DIR%/}/${PROJECT}"
 mkdir -p "${WWW_DIR}"
 
+# tar パスは絶対パス指定を優先（互換のためファイル名のみ指定にも対応）
+if [[ "${TAR_PATH}" != /* ]]; then
+  TAR_PATH="${HOME}/${TAR_PATH}"
+fi
+
+cleanup_tar() {
+  rm -f -- "${TAR_PATH}"
+}
+trap cleanup_tar EXIT
+
 # tar の解凍
-tar xzf "${HOME}/${TAR_NAME}" -C "${WWW_DIR}"
+tar xzf "${TAR_PATH}" -C "${WWW_DIR}"
 
 # ログディレクトリの設定
 ln -s "${HOME}/release/log/${PROJECT}" "${WWW_DIR}/logs"
@@ -108,6 +118,3 @@ if [ "${#RELEASE_DIRS[@]}" -gt "${DELETE_COUNT}" ]; then
     echo "${OLD_DIR}を削除しました。"
   done
 fi
-
-# 利用した tar の削除
-rm "${HOME}/${TAR_NAME}"


### PR DESCRIPTION
## 概要
デプロイワークフローとデプロイスクリプトの tar 取扱いを整理し、転送先を一時ディレクトリ配下に統一しました。

## 変更内容
- `.github/workflows/deploy.yml`
  - リモート tar 配置先を `TAR_REMOTE_PATH` として環境変数化
  - 転送前に `~/release/tmp/${PROJECT}/deploy` を作成
  - `deploy.sh` 実行時の引数を tar ファイル名から tar パスへ変更
- `scripts/deploy.sh`
  - 引数を `<tar_name>` から `<tar_path>` に変更
  - tar パスがファイル名のみの場合は `~/` を補完して互換維持
  - `trap` で tar ファイルを後始末するように変更

## 期待する効果
- デプロイ時の一時ファイル配置場所が明確になる
- ワークフローとスクリプトの引数仕様が一致し、運用が単純になる
