### PR TITLE
デプロイスクリプトから tmp 共有連携とキャッシュ削除を削除

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,9 +39,6 @@ tar xzf "${TAR_PATH}" -C "${WWW_DIR}"
 # ログディレクトリの設定
 ln -s "${HOME}/release/log/${PROJECT}" "${WWW_DIR}/logs"
 
-# 一時ディレクトリの設定
-ln -s "${HOME}/release/tmp/${PROJECT}" "${WWW_DIR}/tmp"
-
 # .env の設定
 ln -s "${HOME}/release/environment/${PROJECT}/.env" "${WWW_DIR}/.env"
 
@@ -57,9 +54,6 @@ composer install \
 
 # マイグレーション実行
 ./bin/cake migrations migrate
-
-# キャッシュ削除
-./bin/cake cache clear_all
 
 # リンク張り替え（ロールバック可能）
 LINK_PATH="${WWW_DIR}/webroot"


### PR DESCRIPTION
## 概要
デプロイスクリプトから、共有 tmp ディレクトリのシンボリックリンク設定とキャッシュ削除処理を削除しました。

## 変更内容
- `scripts/deploy.sh`
  - `tmp` への共有シンボリックリンク作成を削除
  - `./bin/cake cache clear_all` の実行を削除

## 意図
- tmp はリリースごとに再生成される前提のため、共有ディレクトリ連携を不要化
- デプロイ処理を必要最小限にして、スクリプトを簡潔化
