### PR TITLE
RanksTableのfindProfessionalの戻り値型をSelectQueryに修正

### DIFF
--- a/src/Model/Table/RanksTable.php
+++ b/src/Model/Table/RanksTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Model\Table;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Gotea\Model\Entity\Rank;
 
 /**
@@ -22,9 +22,9 @@ class RanksTable extends AppTable
     /**
      * 段位のID・名前を一覧で取得します。
      *
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findProfessional(): Query
+    public function findProfessional(): SelectQuery
     {
         return $this->find()->whereNotNull('rank_numeric')
             ->orderByDesc('rank_numeric')->select(['id', 'name', 'rank_numeric']);


### PR DESCRIPTION
## 概要
`RanksTable::findProfessional()` の戻り値型宣言を、実際の返却型に合わせて修正しました。

## 変更内容
- `use Cake\\ORM\\Query;` を `use Cake\\ORM\\Query\\SelectQuery;` に変更
- `findProfessional()` の戻り値型を `Query` から `SelectQuery` に変更
- PHPDoc の `@return` 型を `SelectQuery` に更新

## 期待される効果
- `findProfessional()` 呼び出し時の戻り値型不一致による `TypeError` を解消
