### PR TITLE
CakePHPの型厳格化に合わせてTable系FinderをSelectQueryへ統一

### DIFF
--- a/src/Model/Table/CountriesTable.php
+++ b/src/Model/Table/CountriesTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Model\Table;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 
 /**
  * 所属国
@@ -22,9 +22,9 @@ class CountriesTable extends AppTable
      * コードが設定されている所属国一覧を取得します。
      *
      * @param bool $hasTitle タイトルを保持しているか
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findAllHasCode(bool $hasTitle = false): Query
+    public function findAllHasCode(bool $hasTitle = false): SelectQuery
     {
         $query = $this->find()->where(['code is not' => null]);
 

--- a/src/Model/Table/NotificationsTable.php
+++ b/src/Model/Table/NotificationsTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Model\Table;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\Validation\Validator;
 
 /**
@@ -80,9 +80,9 @@ class NotificationsTable extends AppTable
     /**
      * 公開日の新しい順に全件取得する。
      *
-     * @return \Cake\ORM\Query
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findAllNewestArrivals(): Query
+    public function findAllNewestArrivals(): SelectQuery
     {
         // 棋士情報の取得
         return $this->find()->orderByDesc('published');

--- a/src/Model/Table/OrganizationsTable.php
+++ b/src/Model/Table/OrganizationsTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Model\Table;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\Validation\Validator;
 
 /**
@@ -35,9 +35,9 @@ class OrganizationsTable extends AppTable
     /**
      * 所属書式をID・名前の一覧で取得します。
      *
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findSorted(): Query
+    public function findSorted(): SelectQuery
     {
         return $this->find('list')->orderBy(['country_id', 'id']);
     }

--- a/src/Model/Table/PlayerRanksTable.php
+++ b/src/Model/Table/PlayerRanksTable.php
@@ -5,7 +5,7 @@ namespace Gotea\Model\Table;
 
 use Cake\Datasource\EntityInterface;
 use Cake\I18n\FrozenDate;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\ResultSet;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
@@ -111,15 +111,15 @@ class PlayerRanksTable extends AppTable
     /**
      * 最近の昇段者を取得します。
      *
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findRecentPromoted(): Query
+    public function findRecentPromoted(): SelectQuery
     {
         return $this->find()
             ->contain([
                 'Players',
                 'Players.Countries',
-                'Ranks' => function (Query $q) {
+                'Ranks' => function (SelectQuery $q) {
                     return $q->where(['rank_numeric >' => 1]);
                 },
             ])

--- a/src/Model/Table/PlayersTable.php
+++ b/src/Model/Table/PlayersTable.php
@@ -5,7 +5,7 @@ namespace Gotea\Model\Table;
 
 use Cake\Datasource\EntityInterface;
 use Cake\I18n\FrozenDate;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -152,9 +152,9 @@ class PlayersTable extends AppTable
      * 指定条件に合致した棋士情報を取得します。
      *
      * @param array $data パラメータ
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findPlayers(array $data): Query
+    public function findPlayers(array $data): SelectQuery
     {
         // 棋士情報の取得
         $query = $this->find()->orderBy([
@@ -249,10 +249,13 @@ class PlayersTable extends AppTable
      * @param int $countryId 所属国ID
      * @param int|null $organizationId 所属組織ID
      * @param bool|null $includeRetired 退役者を検索するか
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findRanksCount(int $countryId, ?int $organizationId = null, ?bool $includeRetired = false): Query
-    {
+    public function findRanksCount(
+        int $countryId,
+        ?int $organizationId = null,
+        ?bool $includeRetired = false,
+    ): SelectQuery {
         $query = $this->find();
 
         if ($organizationId) {
@@ -288,10 +291,10 @@ class PlayersTable extends AppTable
         return $this->get($id, contain: [
             'Countries',
             'Ranks',
-            'TitleScoreDetails' => function (Query $q) {
+            'TitleScoreDetails' => function (SelectQuery $q) {
                 return $q->orderByDesc('target_year');
             },
-            'PlayerRanks' => function (Query $q) {
+            'PlayerRanks' => function (SelectQuery $q) {
                 return $q->orderByDesc('promoted');
             },
             'PlayerRanks.Ranks',

--- a/src/Model/Table/RetentionHistoriesTable.php
+++ b/src/Model/Table/RetentionHistoriesTable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Gotea\Model\Table;
 
 use Cake\Datasource\EntityInterface;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
@@ -27,7 +27,7 @@ class RetentionHistoriesTable extends AppTable
 
         // タイトルマスタ
         $this->belongsTo('Titles')
-            ->setJoinType(Query::JOIN_TYPE_INNER);
+            ->setJoinType(SelectQuery::JOIN_TYPE_INNER);
         // 棋士
         $this->belongsTo('Players');
         // 出場国
@@ -146,9 +146,9 @@ class RetentionHistoriesTable extends AppTable
      * 指定した棋士のタイトル履歴を取得します。
      *
      * @param int $playerId 棋士ID
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findHistoriesByPlayer(int $playerId): Query
+    public function findHistoriesByPlayer(int $playerId): SelectQuery
     {
         return $this->findByPlayerId($playerId)
             ->contain(['Titles.Countries'])
@@ -163,9 +163,9 @@ class RetentionHistoriesTable extends AppTable
      * 指定したタイトルの履歴を取得します。
      *
      * @param int $titleId タイトルID
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findHistoriesByTitle(int $titleId): Query
+    public function findHistoriesByTitle(int $titleId): SelectQuery
     {
         return $this->findByTitleId($titleId)
             ->contain(['Titles'])

--- a/src/Model/Table/TitleScoreDetailsTable.php
+++ b/src/Model/Table/TitleScoreDetailsTable.php
@@ -86,10 +86,10 @@ class TitleScoreDetailsTable extends AppTable
     /**
      * 成績情報のファインダーメソッド。
      *
-     * @param \Cake\ORM\Query $query 生成クエリ
-     * @return \Cake\ORM\Query
+     * @param \Cake\ORM\Query\SelectQuery $query 生成クエリ
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findScores(Query $query): Query
+    public function findScores(SelectQuery $query): SelectQuery
     {
         return $query->contain('TitleScores')->select([
             'player_id' => 'TitleScoreDetails.player_id',
@@ -146,7 +146,7 @@ class TitleScoreDetailsTable extends AppTable
         FrozenDate $started,
         FrozenDate $ended,
         string $type = 'point',
-    ): Query {
+    ): SelectQuery {
         // 旧方式
         if ($this->isOldRanking($started->year)) {
             /** @var \Gotea\Model\Table\PlayerScoresTable $playerScores */

--- a/src/Model/Table/TitleScoresTable.php
+++ b/src/Model/Table/TitleScoresTable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Gotea\Model\Table;
 
 use Cake\Database\Expression\QueryExpression;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
@@ -126,9 +126,9 @@ class TitleScoresTable extends AppTable
      * タイトル勝敗を検索します。
      *
      * @param array $data パラメータ
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findMatches(array $data): Query
+    public function findMatches(array $data): SelectQuery
     {
         $query = $this->find()
             ->contain([
@@ -142,8 +142,8 @@ class TitleScoresTable extends AppTable
 
         $id = Hash::get($data, 'player_id');
         if ($id) {
-            $query->leftJoinWith('TitleScoreDetails', function (Query $q) use ($id) {
-                return $q->innerJoinWith('Players', function (Query $q) use ($id) {
+            $query->leftJoinWith('TitleScoreDetails', function (SelectQuery $q) use ($id) {
+                return $q->innerJoinWith('Players', function (SelectQuery $q) use ($id) {
                     return $q->where(['TitleScoreDetails.player_id' => $id]);
                 });
             });
@@ -217,9 +217,9 @@ class TitleScoresTable extends AppTable
     /**
      * タイトル成績のサマリを取得します
      *
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findSummaryScores(): Query
+    public function findSummaryScores(): SelectQuery
     {
         $query = $this->find();
 

--- a/src/Model/Table/TitlesTable.php
+++ b/src/Model/Table/TitlesTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Model\Table;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -149,9 +149,9 @@ class TitlesTable extends AppTable
     /**
      * 有効なタイトルをID・名前のリストで取得します。
      *
-     * @return \Cake\ORM\Query 生成されたクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成されたクエリ
      */
-    public function findSortedList(): Query
+    public function findSortedList(): SelectQuery
     {
         return $this->find('list')->orderBy(['country_id', 'id']);
     }
@@ -160,13 +160,13 @@ class TitlesTable extends AppTable
      * タイトル情報を取得します。
      *
      * @param array $data パラメータ
-     * @return \Cake\ORM\Query 生成したクエリ
+     * @return \Cake\ORM\Query\SelectQuery 生成したクエリ
      */
-    public function findTitles(array $data = []): Query
+    public function findTitles(array $data = []): SelectQuery
     {
         $query = $this->find()->contain([
             'Countries',
-            'RetentionHistories' => function (Query $q) {
+            'RetentionHistories' => function (SelectQuery $q) {
                 return $q->where(['RetentionHistories.holding = Titles.holding']);
             },
             'RetentionHistories.Titles',


### PR DESCRIPTION
## 概要
CakePHP バージョンアップ後の型厳格化に合わせて、Table クラスの Finder 系メソッドおよび関連クロージャの型を `SelectQuery` に統一しました。

## 変更内容
- `RanksTable::findProfessional()` の戻り値型を `Query` から `SelectQuery` に修正
- 以下 Table クラスの戻り値型・引数型を `SelectQuery` に修正
  - `CountriesTable`
  - `NotificationsTable`
  - `OrganizationsTable`
  - `PlayerRanksTable`
  - `PlayersTable`
  - `RetentionHistoriesTable`
  - `TitleScoreDetailsTable`
  - `TitleScoresTable`
  - `TitlesTable`
- 併せて PHPDoc の型表記も `\Cake\ORM\Query\SelectQuery` に更新

## 目的
- Finder の戻り値型不一致による `TypeError` の発生を防止
- CakePHP の現在の型体系に合わせて、型安全性を向上
