### PR TITLE
勝敗予測用CSVの入力スキーマを拡張

### DIFF
--- a/src/Command/TitleScoreCommand.php
+++ b/src/Command/TitleScoreCommand.php
@@ -47,10 +47,13 @@ class TitleScoreCommand extends Command
 
             $scores = $scores->all()->map(function ($score) {
                 return [
-                    $score->started_timestamp,
+                    $score->match_id,
+                    $score->game_date,
                     $score->player1_id,
                     $score->player2_id,
-                    $score->winner_player_no,
+                    $score->winner_player_id,
+                    $score->event_id,
+                    $score->event_name,
                 ];
             })->toArray();
             foreach ($scores as $fields) {

--- a/src/Model/Table/TitleScoresTable.php
+++ b/src/Model/Table/TitleScoresTable.php
@@ -241,15 +241,15 @@ class TitleScoresTable extends AppTable
                     'conditions' => 'TitleScores.id = tsd.title_score_id',
                 ],
             ])
+            ->leftJoinWith('Titles')
             ->select([
-                'started_timestamp' => $query->func()->unix_timestamp([
-                    'TitleScores.started' => 'identifier',
-                ]),
+                'match_id' => 'TitleScores.id',
+                'game_date' => 'TitleScores.started',
                 'player1_id' => 'tsd.player1_id',
                 'player2_id' => 'tsd.player2_id',
-                'winner_player_no' => $query->expr(
-                    'CASE WHEN tsd.winner_player_id = tsd.player1_id THEN 1 ELSE 2 END',
-                ),
+                'winner_player_id' => 'tsd.winner_player_id',
+                'event_id' => 'TitleScores.title_id',
+                'event_name' => 'Titles.name',
             ]);
     }
 }

--- a/tests/TestCase/Model/Table/TitleScoresTableTest.php
+++ b/tests/TestCase/Model/Table/TitleScoresTableTest.php
@@ -318,10 +318,13 @@ class TitleScoresTableTest extends TestCase
         $scores = $this->TitleScores->findSummaryScores();
         $this->assertGreaterThan(0, $scores->count());
         $scores->all()->each(function ($item) {
-            $this->assertNotNull($item->started_timestamp);
+            $this->assertGreaterThan(0, $item->match_id);
+            $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $item->game_date->format('Y-m-d'));
             $this->assertGreaterThan(0, $item->player1_id);
             $this->assertGreaterThan(0, $item->player2_id);
-            $this->assertContains($item->winner_player_no, [1, 2]);
+            $this->assertContains($item->winner_player_id, [$item->player1_id, $item->player2_id]);
+            $this->assertGreaterThan(0, $item->event_id);
+            $this->assertNotEmpty($item->event_name);
         });
     }
 }


### PR DESCRIPTION
## 概要
Issue #1441 の対応として、勝敗予測モデル向けCSVの出力項目を拡張しました。

## 変更内容
- TitleScoresTable::findSummaryScores() の取得項目を更新
  - match_id（TitleScores.id）
  - game_date（TitleScores.started）
  - winner_player_id（実際の棋士ID）
  - event_id（TitleScores.title_id）
  - event_name（Titles.name）
- Titles を結合し、棋戦情報を同時に取得
- TitleScoreCommand のCSV出力列を新スキーマへ変更
- TitleScoresTableTest::testFindSummaryScores() を新仕様に合わせて更新

## 確認
- 関連テストが通ることを確認済み

Closes #1441
