### PR TITLE
動的プロパティに関する非推奨警告の解消

### DIFF
--- a/src/Command/RankDiffCommand.php
+++ b/src/Command/RankDiffCommand.php
@@ -28,8 +28,8 @@ use Throwable;
  */
 class RankDiffCommand extends Command
 {
-    private CountriesTable $Countries;
-    private RanksTable $Ranks;
+    protected CountriesTable $Countries;
+    protected RanksTable $Ranks;
 
     /**
      * @inheritDoc

--- a/src/Command/RankDiffCommand.php
+++ b/src/Command/RankDiffCommand.php
@@ -15,6 +15,8 @@ use Gotea\Command\SubCommand\RankDiffKoreaSubCommand;
 use Gotea\Command\SubCommand\RankDiffSubCommandInterface;
 use Gotea\Command\SubCommand\RankDiffTaiwanSubCommand;
 use Gotea\Model\Entity\Country;
+use Gotea\Model\Table\CountriesTable;
+use Gotea\Model\Table\RanksTable;
 use LogicException;
 use Throwable;
 
@@ -26,6 +28,9 @@ use Throwable;
  */
 class RankDiffCommand extends Command
 {
+    private CountriesTable $Countries;
+    private RanksTable $Ranks;
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
### 概要

- close #1462 

### 対応内容

- 段位差分出力コマンドで動的プロパティの利用をやめる
