### PR TITLE
node のバージョンアップ

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -12,9 +12,9 @@ jobs:
       run:
         working-directory: infra
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     container:
       image: ghcr.io/gotoeveryone/composer-php:8.4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: vendor_cache
         with:
           path: vendor
@@ -28,9 +28,9 @@ jobs:
   code_check_frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.16"
           cache: "npm"
@@ -75,7 +75,7 @@ jobs:
             -d \
             -p ${DB_TEST_PORT}:3306 \
             mariadb:10.5 mariadbd --character-set-server=${DB_TEST_ENCODING} --collation-server=${DB_TEST_ENCODING}_general_ci
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -88,7 +88,7 @@ jobs:
             sleep 1
           done
       - name: Cache modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: vendor_cache
         with:
           path: vendor
@@ -105,9 +105,9 @@ jobs:
   test_frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.16"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24.13"
+          node-version: "24.16"
           cache: "npm"
           cache-dependency-path: package-lock.json
-      - name: Use npm 11.10.0
-        run: npm i -g npm@11.10.0
       - name: Install dependencies
         run: npm ci
       - name: Execute code check
@@ -111,11 +109,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24.13"
+          node-version: "24.16"
           cache: "npm"
           cache-dependency-path: package-lock.json
-      - name: Use npm 11.10.0
-        run: npm i -g npm@11.10.0
       - name: Install dependencies
         run: npm ci
       - name: Execute code check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,11 +21,11 @@ jobs:
       PUBLIC_DIR: '${{ secrets.PUBLIC_DIR }}'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.16"
           cache: "npm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24.13"
+          node-version: "24.16"
           cache: "npm"
           cache-dependency-path: package-lock.json
-      - name: Use npm 11.10.0
-        run: npm i -g npm@11.10.0
       - name: Install dependencies
         run: npm ci
       - name: Build assets

--- a/compose.yml
+++ b/compose.yml
@@ -12,7 +12,7 @@ services:
     working_dir: /src
     command: sh -c 'composer install -n && ./bin/cake server --host 0.0.0.0'
   frontend:
-    image: node:24.13
+    image: node:24.16
     volumes:
       - ./:/src
       - node_modules:/src/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "vitest": "^4.1.8"
       },
       "engines": {
-        "node": ">=24 <25",
-        "npm": ">=10"
+        "node": ">=24.16 <25",
+        "npm": ">=11"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "vitest": "^4.1.8"
   },
   "engines": {
-    "node": ">=24 <25",
-    "npm": ">=10"
+    "node": ">=24.16 <25",
+    "npm": ">=11"
   },
   "license": "MIT",
   "type": "module"


### PR DESCRIPTION
### 概要

- node バージョンアップ他

### 対応内容

- 利用する Node を 24.16 に
- 上記に伴い npm も 11 が既定になるため、個別のインストール手順を削除
- actions の各 action も Node24 を利用するものに変更
