### PR TITLE
日付変更時の不要なイベントを削除

### DIFF
--- a/resources/assets/scripts/components/titles/AddHistory.vue
+++ b/resources/assets/scripts/components/titles/AddHistory.vue
@@ -32,7 +32,6 @@
             type="date"
             class="acquired date-input"
             name="acquired"
-            @change="onChangeAcquired"
           />
         </div>
       </div>
@@ -45,7 +44,6 @@
             type="date"
             class="broadcasted date-input"
             name="broadcasted"
-            @change="onChangeBroadcasted"
           />
         </div>
       </div>
@@ -236,18 +234,6 @@ export default defineComponent({
     },
     getTeamHidden(value: boolean) {
       return value ? '1' : '';
-    },
-    onChangeAcquired($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      if (this.acquired !== target.value) {
-        this.acquired = target.value;
-      }
-    },
-    onChangeBroadcasted($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      if (this.broadcasted !== target.value) {
-        this.broadcasted = target.value;
-      }
     },
     search() {
       if (this.name === '') {

--- a/resources/assets/scripts/components/titles/Item.vue
+++ b/resources/assets/scripts/components/titles/Item.vue
@@ -46,7 +46,7 @@
         :disabled="!isAdmin"
         type="date"
         class="date-input table-column_modified-input"
-        @change="onChangeHtmlFileModified($event)"
+        @change="onChangeHtmlFileModified()"
       />
     </span>
     <span class="table-column table-column_closed">
@@ -155,12 +155,8 @@ export default defineComponent({
           });
         });
     },
-    onChangeHtmlFileModified($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      if (this.localItem.htmlFileModified !== target.value) {
-        this.localItem.htmlFileModified = target.value;
-        this.save();
-      }
+    onChangeHtmlFileModified() {
+      this.save();
     },
   },
 });


### PR DESCRIPTION
### 概要

- #1563 の対応漏れ

### 対応内容

- `type="date"` を使うことで、日付変更時に onChange をコールせずとも値が変わるようになった
- 上記に伴い、不要な代入処理を削除
