### PR TITLE
UsersSeed の PasswordHasher 名前空間を修正

### DIFF
--- a/config/Seeds/UsersSeed.php
+++ b/config/Seeds/UsersSeed.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Auth\DefaultPasswordHasher;
+use Authentication\PasswordHasher\DefaultPasswordHasher;
 use Migrations\AbstractSeed;
 
 /**


### PR DESCRIPTION
## What changed
- `config/Seeds/UsersSeed.php` の import を `Cake\\Auth\\DefaultPasswordHasher` から `Authentication\\PasswordHasher\\DefaultPasswordHasher` に修正しました。
- CakePHP 5 + Authentication プラグイン構成での正規名称空間へ合わせ、シード実行時のハッシュ生成を正しく解決できるようにしました。

## Why
- バージョンアップで認証ハッシャーのクラス移動/名前空間変更があり、旧パスが認識されない状態だったため。

## Impact
- `bin/cake migrations seed` 時の `UsersSeed` が正常に実行されるようになります。
