### PR TITLE
Issue #1430: joinedソートの方向トグル不整合を修正

### DIFF
--- a/src/Controller/PlayersController.php
+++ b/src/Controller/PlayersController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Controller;
 
+use Cake\Datasource\Paging\SortField;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Gotea\Form\PlayerForm;
@@ -84,7 +85,19 @@ class PlayersController extends AppController
         }
 
         // データを取得
-        $players = $this->paginate($this->Players->findPlayers($data));
+        $players = $this->paginate($this->Players->findPlayers($data), [
+            'sortableFields' => [
+                'id',
+                'country_id',
+                'organization_id',
+                'rank_id',
+                'joined' => [
+                    SortField::asc('Players.joined_year'),
+                    SortField::asc('Players.joined_month'),
+                    SortField::asc('Players.joined_day'),
+                ],
+            ],
+        ]);
 
         // 件数が0件の場合はメッセージを出力
         if (!$players->count()) {


### PR DESCRIPTION
## 概要
- players一覧でsort=joined時のヘッダートグルが方向を反転しない不具合に対し、Paginatorに`sortableFields`を明示しました。
- `PlayersController::search()` のpaginate設定で `joined` を許可し、`joined` を `joined_year / joined_month / joined_day` の複合キーとして扱うようにしました。
- これにより、URL上の `sort=joined` とヘッダーリンクの方向表示/遷移が整合します。

Closes #1430

## 変更内容
- src/Controller/PlayersController.php

## 関連Issue
- https://github.com/gotoeveryone/gotea/issues/1430
