### PR TITLE
API titles update route の typo を修正し、回帰テストを追加

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -184,7 +184,7 @@ return static function (RouteBuilder $routes): void {
         $routes->scope('/titles', ['controller' => 'Titles'], function (RouteBuilder $routes): void {
             $routes->get('/', ['action' => 'index'], 'api_titles');
             $routes->post('/', ['action' => 'create'], 'api_create_titles');
-            $routes->put('//{id}', ['action' => 'update'], 'api_update_titles')
+            $routes->put('/{id}', ['action' => 'update'], 'api_update_titles')
                 ->setPatterns(['id' => RouteBuilder::ID])->setPass(['id']);
             $routes->post('/news', ['action' => 'createNews'], 'api_news');
         });

--- a/tests/TestCase/Controller/Api/TitlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/TitlesControllerTest.php
@@ -3,11 +3,22 @@ declare(strict_types=1);
 
 namespace Gotea\Test\TestCase\Controller\Api;
 
+use Cake\ORM\TableRegistry;
+
 /**
  * Gotea\Controller\Api\TitlesController Test Case
+ *
+ * @property \Gotea\Model\Table\TitlesTable $Titles
  */
 class TitlesControllerTest extends ApiTestCase
 {
+    /**
+     * タイトルモデル
+     *
+     * @var \Gotea\Model\Table\TitlesTable
+     */
+    public $Titles;
+
     /**
      * Fixtures
      *
@@ -28,6 +39,7 @@ class TitlesControllerTest extends ApiTestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->Titles = TableRegistry::getTableLocator()->get('Titles');
         $this->createSession();
     }
 
@@ -114,5 +126,50 @@ class TitlesControllerTest extends ApiTestCase
         ]);
         $this->assertResponseSuccess();
         $this->assertJsonContentType();
+    }
+
+    /**
+     * データ更新（不正パラメータ）
+     *
+     * @return void
+     */
+    public function testUpdateInvalidParameter()
+    {
+        $this->put('/api/titles/1', [
+            'country_id' => 1,
+            'name' => 'test',
+            'nameEnglish' => '',
+            'holding' => 1,
+            'sort_order' => 1,
+            'htmlFileName' => '',
+            'htmlFileModified' => '',
+        ]);
+        $this->assertResponseCode(400);
+        $this->assertJsonContentType();
+    }
+
+    /**
+     * データ更新（成功）
+     *
+     * @return void
+     */
+    public function testUpdate()
+    {
+        $this->put('/api/titles/1', [
+            'country_id' => 1,
+            'name' => 'test update',
+            'name_english' => 'test update',
+            'holding' => 2,
+            'sort_order' => 2,
+            'htmlFileName' => 'test-update',
+            'htmlFileModified' => '2018-01-01',
+        ]);
+        $this->assertResponseSuccess();
+        $this->assertJsonContentType();
+
+        $title = $this->Titles->get(1);
+        $this->assertEquals('test update', $title->name);
+        $this->assertEquals(2, $title->holding);
+        $this->assertEquals('test-update', $title->html_file_name);
     }
 }


### PR DESCRIPTION
## 概要

- `config/routes.php` の API titles update route 定義を `//{id}` から `/{id}` に修正しました。
- `PUT /api/titles/{id}` の成功系・異常系テストを追加しました。
- 成功系ではレスポンスだけでなく、保存後の `Titles` レコード更新も確認しています。

## 背景

`api_update_titles` は route 一覧上では `/api/titles/{id}` として機能していましたが、設定値が `//{id}` になっており typo に見える状態でした。設定の可読性を修正しつつ、今後 `PUT /api/titles/{id}` が Controller まで届くことをテストで担保します。

## 確認

- `docker compose exec backend ./bin/cake routes`
  - `api_update_titles` が `/api/titles/{id}` のままであることを確認
- `docker compose exec backend composer test -- --filter TitlesControllerTest`
- `docker compose exec backend composer cs-check`
- `docker compose exec backend composer test`
  - PHPUnit Deprecations が 1 件ありますが、テストは成功しています。

Closes #1592