### PR TITLE
ダイアログメッセージをテキスト描画に変更

### DIFF
--- a/resources/assets/scripts/components/parts/Dialog.test.ts
+++ b/resources/assets/scripts/components/parts/Dialog.test.ts
@@ -6,13 +6,13 @@ const messages = ['hoge', 'fuga'];
 
 const mockOpenDialog = vi.fn();
 const mockCloseDialog = vi.fn();
-const createStoreMock = (type = 'info') =>
+const createStoreMock = (type = 'info', storeMessages = messages) =>
   createStore({
     getters: {
       dialogOptions: () => () => {
         return {
           type,
-          messages,
+          messages: storeMessages,
           modalColor: '#f00',
         };
       },
@@ -43,6 +43,12 @@ describe('ダイアログ', () => {
     test('コンテンツが表示される', () => {
       const wrapper = createWrapper(createStoreMock());
       expect(wrapper.findAll('li')).toHaveLength(messages.length);
+    });
+    test('メッセージはHTMLとして描画されない', () => {
+      const htmlMessage = '<img src=x onerror=alert(1)>タイトル';
+      const wrapper = createWrapper(createStoreMock('info', [htmlMessage]));
+      expect(wrapper.find('li').text()).toBe(htmlMessage);
+      expect(wrapper.find('li').html()).not.toContain('<img');
     });
     test.each(['info', 'warn', 'error'])(
       'メッセージに type: %s を利用したクラスが設定される',

--- a/resources/assets/scripts/components/parts/Dialog.vue
+++ b/resources/assets/scripts/components/parts/Dialog.vue
@@ -8,9 +8,7 @@
         <div class="dialog-content-body">
           <div class="dialog-content-body-text">
             <ul :class="messageClass">
-              <!-- eslint-disable vue/no-v-html -->
-              <li v-for="(message, idx) in messages" :key="idx" v-html="message" />
-              <!-- eslint-enable vue/no-v-html -->
+              <li v-for="(message, idx) in messages" :key="idx" v-text="message" />
             </ul>
           </div>
         </div>
@@ -168,6 +166,7 @@ watch(isShow, (newVal, oldVal) => {
 
 .message {
   margin: 0;
+  white-space: pre-line;
 }
 
 .message-info {

--- a/resources/locales/ja_JP/default.po
+++ b/resources/locales/ja_JP/default.po
@@ -39,10 +39,6 @@ msgstr "昇段情報を保存しました"
 msgid "No matches found"
 msgstr "検索結果が0件でした"
 
-#: Controller/PlayersController.php:67 Controller/TitleScoresController.php:60
-msgid "Matched rows more than {0} ({1} row matched).<br/>Please filtering conditions and reexecute."
-msgstr "検索結果が{0}件を超えています（{1}件）<br/>条件を絞って再検索してください"
-
 #: Controller/PlayersController.php:148;185
 msgid "The player {0} - {1} is saved"
 msgstr "[{0}: {1}] を保存しました"

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -26,7 +26,9 @@ class AppExceptionRenderer extends WebExceptionRenderer
 
         if ($this->error instanceof PDOException) {
             $this->controller->log($this->error->getMessage(), LogLevel::ERROR);
-            $this->controller->Flash->error(__('Executing query failed.<br/>Please confirm logfile.'));
+            $this->controller->Flash->error(__(
+                "Executing query failed.\nPlease confirm logfile.",
+            ));
         }
 
         return parent::render();


### PR DESCRIPTION
## 概要

- ダイアログメッセージの `v-html` を廃止し、`v-text` でテキストとして描画するように変更しました。
- 改行を含むメッセージを表示できるよう、ダイアログ本文に `white-space: pre-line` を設定しました。
- PDO 例外時の Flash メッセージで使っていた `<br/>` を `\n` に変更しました。
- 未使用だった `<br/>` 付き翻訳エントリを削除しました。

## 背景

入力値を含むメッセージが `v-html` で描画されると、HTML として解釈される可能性がありました。ダイアログは原則テキスト表示に寄せ、HTML 表示を前提にしたメッセージも残さないようにしています。

Closes #1586

## 確認

- `npm run lint`
- `npm test -- --run`
- `php -l src/Error/AppExceptionRenderer.php`
- `rg "<br/>|<br>|v-html|vue/no-v-html|Matched rows more|検索結果が.*超えています|Please filtering conditions|条件を絞って再検索" src resources/assets/scripts resources/locales/ja_JP templates/element/flash -n` で該当なし
