### PR TITLE
API の認可チェックを共通化する

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -472,7 +472,7 @@ return [
     'DebugKit' => [
         'forceEnable' => filter_var(env('DEBUG_KIT_FORCE_ENABLE', false), FILTER_VALIDATE_BOOLEAN),
         'safeTld' => env('DEBUG_KIT_SAFE_TLD', null),
-        'ignoreAuthorization' => env('DEBUG_KIT_IGNORE_AUTHORIZATION', false),
+        'ignoreAuthorization' => env('DEBUG_KIT_IGNORE_AUTHORIZATION', true),
     ],
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -108,7 +108,7 @@ class Application extends BaseApplication implements
 
             // Add authorization middleware.
             ->add(new AuthorizationMiddleware($this, [
-                'requireAuthorizationCheck' => false,
+                'requireAuthorizationCheck' => true,
                 'unauthorizedHandler' => [
                     'className' => 'Authorization.Redirect',
                     'url' => '/',

--- a/src/Controller/Api/ApiController.php
+++ b/src/Controller/Api/ApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Gotea\Controller\Api;
 
 use Cake\Controller\Controller;
+use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Gotea\Controller\JsonResponseTrait;
 use Gotea\Event\LoggedUser;
@@ -17,6 +18,13 @@ use Gotea\Event\LoggedUser;
 abstract class ApiController extends Controller
 {
     use JsonResponseTrait;
+
+    /**
+     * 認証・認可なしで利用できる action
+     *
+     * @var array<string>
+     */
+    protected array $publicActions = [];
 
     /**
      * @inheritDoc
@@ -38,5 +46,23 @@ abstract class ApiController extends Controller
             // モデル側のインスタンスイベントより先に実行する必要があるため、グローバルイベントマネージャに登録する
             EventManager::instance()->on(new LoggedUser($user->getOriginalData()));
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeFilter(EventInterface $event)
+    {
+        parent::beforeFilter($event);
+
+        $action = (string)$this->getRequest()->getParam('action');
+        if (in_array($action, $this->publicActions, true)) {
+            $this->Authentication->allowUnauthenticated($this->publicActions);
+            $this->Authorization->skipAuthorization();
+
+            return;
+        }
+
+        $this->Authorization->authorize($this->request, 'access');
     }
 }

--- a/src/Controller/Api/CountriesController.php
+++ b/src/Controller/Api/CountriesController.php
@@ -13,6 +13,11 @@ use Cake\Http\Response;
 class CountriesController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['index'];
+
+    /**
      * 所属国一覧を取得します。
      *
      * @return \Cake\Http\Response 所属国一覧

--- a/src/Controller/Api/NotificationsController.php
+++ b/src/Controller/Api/NotificationsController.php
@@ -14,6 +14,11 @@ use Cake\Http\Response;
 class NotificationsController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['index'];
+
+    /**
      * Index method
      *
      * @return \Cake\Http\Response

--- a/src/Controller/Api/PlayersController.php
+++ b/src/Controller/Api/PlayersController.php
@@ -21,6 +21,11 @@ use Gotea\Utility\FileBuilder;
  */
 class PlayersController extends ApiController
 {
+    /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['search', 'searchRanks', 'searchRanking'];
+
     protected CountriesTable $Countries;
     protected TitleScoreDetailsTable $TitleScoreDetails;
 

--- a/src/Controller/Api/RanksController.php
+++ b/src/Controller/Api/RanksController.php
@@ -13,6 +13,11 @@ use Cake\Http\Response;
 class RanksController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['index'];
+
+    /**
      * 段位一覧を取得します。
      *
      * @return \Cake\Http\Response 段位一覧

--- a/src/Controller/Api/RetentionHistoriesController.php
+++ b/src/Controller/Api/RetentionHistoriesController.php
@@ -13,6 +13,11 @@ use Cake\Http\Response;
 class RetentionHistoriesController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['view'];
+
+    /**
      * 履歴を1件取得します。
      *
      * @param int $id ID

--- a/src/Controller/Api/TableTemplatesController.php
+++ b/src/Controller/Api/TableTemplatesController.php
@@ -14,6 +14,11 @@ use Cake\Http\Response;
 class TableTemplatesController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['index'];
+
+    /**
      * Index method
      *
      * @return \Cake\Http\Response

--- a/src/Controller/Api/TitlesController.php
+++ b/src/Controller/Api/TitlesController.php
@@ -16,6 +16,11 @@ use Gotea\Utility\FileBuilder;
 class TitlesController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['index'];
+
+    /**
      * タイトルを検索します。
      *
      * @return \Cake\Http\Response|null

--- a/src/Controller/Api/YearsController.php
+++ b/src/Controller/Api/YearsController.php
@@ -12,6 +12,11 @@ use Cake\I18n\FrozenDate;
 class YearsController extends ApiController
 {
     /**
+     * @inheritDoc
+     */
+    protected array $publicActions = ['index'];
+
+    /**
      * 管理対象年を取得します。
      *
      * @return \Cake\Http\Response 年一覧

--- a/src/Controller/PlayersController.php
+++ b/src/Controller/PlayersController.php
@@ -48,7 +48,9 @@ class PlayersController extends AppController
      */
     public function beforeFilter(EventInterface $event)
     {
-        if ($this->request->getParam('action') !== 'index') {
+        if ($this->request->getParam('action') === 'index') {
+            $this->Authorization->skipAuthorization();
+        } else {
             $this->Authorization->authorize($this->request, 'access');
         }
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\View\Helper;
 
+use Cake\Utility\Inflector;
 use Cake\View\Helper\HtmlHelper as BaseHtmlHelper;
 
 /**
@@ -96,6 +97,11 @@ class HtmlHelper extends BaseHtmlHelper
             return $path;
         }
 
+        $pluginAssetPath = $this->resolvePluginAssetPath($path);
+        if ($pluginAssetPath !== null) {
+            return $pluginAssetPath;
+        }
+
         $map = $this->getViteAssetMap();
         if ($map === []) {
             return $path;
@@ -116,6 +122,24 @@ class HtmlHelper extends BaseHtmlHelper
     private function isExternalAsset(string $path): bool
     {
         return preg_match('/^[a-z][a-z0-9+.-]*:/i', $path) === 1;
+    }
+
+    /**
+     * @param string $path アセットパス
+     * @return string|null 解決後のプラグインアセットパス
+     */
+    private function resolvePluginAssetPath(string $path): ?string
+    {
+        if (!preg_match('/^([A-Za-z][A-Za-z0-9_\/-]*)\.\/(.+)$/', $path, $matches)) {
+            return null;
+        }
+
+        $pluginPath = implode('/', array_map(
+            Inflector::underscore(...),
+            explode('/', $matches[1]),
+        ));
+
+        return '/' . $pluginPath . '/' . ltrim($matches[2], '/');
     }
 
     /**

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -93,4 +93,14 @@ class ApplicationTest extends TestCase
             $this->assertInstanceOf($target, $middleware->current());
         }
     }
+
+    /**
+     * testDebugKitAuthorization
+     *
+     * @return void
+     */
+    public function testDebugKitAuthorization()
+    {
+        $this->assertTrue(Configure::read('DebugKit.ignoreAuthorization'));
+    }
 }

--- a/tests/TestCase/Controller/Api/PlayersControllerTest.php
+++ b/tests/TestCase/Controller/Api/PlayersControllerTest.php
@@ -360,6 +360,19 @@ class PlayersControllerTest extends ApiTestCase
     }
 
     /**
+     * ランキング作成（管理者以外）
+     *
+     * @return void
+     */
+    public function testCreateRankingForbiddenForNonAdmin()
+    {
+        $this->createSession(false);
+
+        $this->post('/api/players/ranking/jp/2017/20');
+        $this->assertResponseCode(302);
+    }
+
+    /**
      * ランキング作成（データあり・FROM指定）
      *
      * @return void

--- a/tests/TestCase/Controller/Api/TitlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/TitlesControllerTest.php
@@ -129,6 +129,29 @@ class TitlesControllerTest extends ApiTestCase
     }
 
     /**
+     * データ登録（管理者以外）
+     *
+     * @return void
+     */
+    public function testCreateForbiddenForNonAdmin()
+    {
+        $count = $this->Titles->find()->count();
+        $this->createSession(false);
+
+        $this->post('/api/titles', [
+            'country_id' => 1,
+            'name' => 'test',
+            'name_english' => 'test',
+            'holding' => 1,
+            'sort_order' => 1,
+            'htmlFileName' => 'test',
+            'htmlFileModified' => '2018-01-01',
+        ]);
+        $this->assertResponseCode(302);
+        $this->assertSame($count, $this->Titles->find()->count());
+    }
+
+    /**
      * データ更新（不正パラメータ）
      *
      * @return void
@@ -171,5 +194,30 @@ class TitlesControllerTest extends ApiTestCase
         $this->assertEquals('test update', $title->name);
         $this->assertEquals(2, $title->holding);
         $this->assertEquals('test-update', $title->html_file_name);
+    }
+
+    /**
+     * データ更新（管理者以外）
+     *
+     * @return void
+     */
+    public function testUpdateForbiddenForNonAdmin()
+    {
+        $this->createSession(false);
+
+        $this->put('/api/titles/1', [
+            'country_id' => 1,
+            'name' => 'test update',
+            'name_english' => 'test update',
+            'holding' => 2,
+            'sort_order' => 2,
+            'htmlFileName' => 'test-update',
+            'htmlFileModified' => '2018-01-01',
+        ]);
+        $this->assertResponseCode(302);
+
+        $title = $this->Titles->get(1);
+        $this->assertNotEquals('test update', $title->name);
+        $this->assertNotEquals('test-update', $title->html_file_name);
     }
 }

--- a/tests/TestCase/Controller/AppTestCase.php
+++ b/tests/TestCase/Controller/AppTestCase.php
@@ -34,14 +34,14 @@ abstract class AppTestCase extends TestCase
      *
      * @return void
      */
-    protected function createSession()
+    protected function createSession(bool $isAdmin = true)
     {
         $this->session([
             'Auth' => [
                 'id' => 1,
                 'account' => 'testuser',
                 'name' => 'テスト',
-                'is_admin' => true,
+                'is_admin' => $isAdmin,
             ],
         ]);
     }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -25,18 +25,6 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
-     * Vite manifest のエントリはビルド済みファイルに解決されること
-     *
-     * @return void
-     */
-    public function testScriptResolvesViteAsset(): void
-    {
-        $html = $this->helper->script('main');
-
-        $this->assertStringContainsString('src="/js/main-DYkXVuEg.js', $html);
-    }
-
-    /**
      * プラグインアセットは Vite manifest の同名エントリに解決されないこと
      *
      * @return void
@@ -46,6 +34,5 @@ class HtmlHelperTest extends TestCase
         $html = $this->helper->script('DebugKit./js/main', ['type' => 'module']);
 
         $this->assertStringContainsString('src="/debug_kit/js/main.js', $html);
-        $this->assertStringNotContainsString('/js/main-DYkXVuEg.js', $html);
     }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Test\TestCase\View\Helper;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Gotea\View\Helper\HtmlHelper;
+
+/**
+ * HtmlHelper Test Case
+ */
+class HtmlHelperTest extends TestCase
+{
+    private HtmlHelper $helper;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->helper = new HtmlHelper(new View());
+    }
+
+    /**
+     * Vite manifest のエントリはビルド済みファイルに解決されること
+     *
+     * @return void
+     */
+    public function testScriptResolvesViteAsset(): void
+    {
+        $html = $this->helper->script('main');
+
+        $this->assertStringContainsString('src="/js/main-DYkXVuEg.js', $html);
+    }
+
+    /**
+     * プラグインアセットは Vite manifest の同名エントリに解決されないこと
+     *
+     * @return void
+     */
+    public function testScriptDoesNotResolvePluginAssetAsViteAsset(): void
+    {
+        $html = $this->helper->script('DebugKit./js/main', ['type' => 'module']);
+
+        $this->assertStringContainsString('src="/debug_kit/js/main.js', $html);
+        $this->assertStringNotContainsString('/js/main-DYkXVuEg.js', $html);
+    }
+}


### PR DESCRIPTION
### 概要

- API 基底 Controller で認可チェックを共通実行するようにしました
- 公開 API は各 API Controller の `publicActions` で明示し、認可漏れ検知を有効化しました
- DebugKit が認可チェックや Vite manifest 解決の影響で利用できなくならないようにしました
- closes #1585

### 対応内容

- `ApiController::beforeFilter()` で公開 action は `skipAuthorization()`、それ以外は `RequestPolicy::canAccess()` による認可を実行
- 各 API Controller に公開 action を明示
- `AuthorizationMiddleware` の `requireAuthorizationCheck` を `true` に変更
- 既存の通常画面 `PlayersController::index` は認可対象外であることを明示
- `DebugKit.ignoreAuthorization` のデフォルトを `true` に変更
- `HtmlHelper` の Vite manifest 解決で `DebugKit./js/main` などの plugin asset がアプリ側 asset に誤解決されないように修正
- 更新系 API が非管理者では拒否されるテストを追加
- DebugKit 設定と plugin asset 解決のテストを追加

### 確認

- `docker compose exec backend composer test -- --filter ApplicationTest`
- `docker compose exec backend composer test -- --filter HtmlHelperTest`
- `docker compose exec backend composer cs-check`
- `docker compose exec backend composer test`
- ブラウザで DebugKit の Cake アイコンをクリックし、デバッグバーが表示されることを確認
