### PR TITLE
ログアウトをPOSTに変更する

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -58,7 +58,7 @@ return static function (RouteBuilder $routes): void {
         $routes->scope('/', ['controller' => 'Users'], function (RouteBuilder $routes): void {
             $routes->get('/', ['action' => 'index'], 'top');
             $routes->post('/login', ['action' => 'login'], 'login');
-            $routes->get('/logout', ['action' => 'logout'], 'logout');
+            $routes->post('/logout', ['action' => 'logout'], 'logout');
         });
 
         $routes->scope('/players', ['controller' => 'Players'], function (RouteBuilder $routes): void {

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -33,7 +33,7 @@ declare(strict_types=1);
                 <div class="other">
                     <?php if ($this->Identity->isLoggedIn()) : ?>
                         <span class="username"><?= h($this->Identity->get('name')) ?>でログイン中</span>
-                        <?= $this->Html->link('ログアウト', ['_name' => 'logout']); ?>
+                        <?= $this->Form->postLink('ログアウト', ['_name' => 'logout']); ?>
                     <?php endif ?>
                 </div>
             </header>

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -123,7 +123,20 @@ class UsersControllerTest extends AppTestCase
     public function testLogout()
     {
         $this->createSession();
-        $this->get('/logout');
+        $this->enableCsrfToken();
+        $this->post('/logout');
         $this->assertResponseCode(302);
+    }
+
+    /**
+     * ログアウト（GETは許可しない）
+     *
+     * @return void
+     */
+    public function testLogoutGetNotAllowed()
+    {
+        $this->createSession();
+        $this->get('/logout');
+        $this->assertResponseCode(404);
     }
 }


### PR DESCRIPTION
### 概要

- closes #1591
- ログアウトを GET ではなく POST で実行するように変更しました。

### 対応内容

- /logout の route を POST に変更
- ヘッダーのログアウト UI を CSRF トークン付きの postLink に変更
- ログアウトの POST 成功と GET 不可を確認するテストを追加

### 確認内容

- docker compose exec backend composer test
- docker compose exec backend composer cs-check