### PR TITLE
FileBuilder のパス検証を追加する

### DIFF
--- a/src/Controller/Api/PlayersController.php
+++ b/src/Controller/Api/PlayersController.php
@@ -127,7 +127,7 @@ class PlayersController extends ApiController
 
         $filename = strtolower($ranking['countryName']) . $ranking['year'];
         $builder = FileBuilder::new();
-        $builder->setParentDir('ranking' . DS . $ranking['countryCode']);
+        $builder->setParentDirPath('ranking', $ranking['countryCode']);
         if (!$builder->output($filename, $ranking)) {
             return $this->renderError(500, 'JSON出力失敗');
         }

--- a/src/Utility/FileBuilder.php
+++ b/src/Utility/FileBuilder.php
@@ -5,6 +5,7 @@ namespace Gotea\Utility;
 
 use Cake\Core\Configure;
 use Cake\Log\Log;
+use InvalidArgumentException;
 use RuntimeException;
 use SplFileObject;
 
@@ -14,9 +15,9 @@ use SplFileObject;
 class FileBuilder
 {
     /**
-     * @var string $parentDir
+     * @var list<string> $parentDirPath
      */
-    private ?string $parentDir = null;
+    private array $parentDirPath = [];
 
     /**
      * Constructor
@@ -42,7 +43,7 @@ class FileBuilder
      */
     public function getDir(): string
     {
-        return Configure::read('App.jsonDir') . DS . ($this->parentDir ? $this->parentDir . DS : '');
+        return $this->buildDirPath();
     }
 
     /**
@@ -53,7 +54,29 @@ class FileBuilder
      */
     public function setParentDir(string $dir)
     {
-        $this->parentDir = $dir;
+        $this->validatePathSegment($dir, 'parentDir');
+        $this->parentDirPath = [$dir];
+
+        return $this;
+    }
+
+    /**
+     * 親ディレクトリのパスを設定する
+     *
+     * @param string ...$segments 親ディレクトリのパス要素
+     * @return $this
+     */
+    public function setParentDirPath(string ...$segments)
+    {
+        if (!$segments) {
+            throw new InvalidArgumentException('親ディレクトリが指定されていません');
+        }
+
+        foreach ($segments as $segment) {
+            $this->validatePathSegment($segment, 'parentDir');
+        }
+
+        $this->parentDirPath = $segments;
 
         return $this;
     }
@@ -68,16 +91,13 @@ class FileBuilder
     public function output(string $filename, mixed $data): bool
     {
         try {
-            // フォルダ作成
-            $dirpath = $this->getDir();
-            if (!file_exists($dirpath) && !mkdir($dirpath, 0755, true)) {
-                Log::error("ディレクトリ作成に失敗しました: {$dirpath}");
+            $this->validatePathSegment($filename, 'filename');
 
-                return false;
-            }
+            // フォルダ作成
+            $dirpath = $this->prepareOutputDir();
+            $filepath = $dirpath . DS . "{$filename}.json";
 
             // ファイル作成
-            $filepath = $dirpath . DS . "{$filename}.json";
             $file = new SplFileObject($filepath, 'w');
             if (!$file->fwrite(json_encode($data))) {
                 Log::error("ファイル作成に失敗しました: {$filepath}");
@@ -86,10 +106,86 @@ class FileBuilder
             }
 
             return true;
-        } catch (RuntimeException $e) {
+        } catch (InvalidArgumentException | RuntimeException $e) {
             Log::error($e->getMessage());
 
             return false;
         }
+    }
+
+    /**
+     * 操作対象のディレクトリパスを生成する
+     *
+     * @return string
+     */
+    private function buildDirPath(): string
+    {
+        $dir = rtrim((string)Configure::read('App.jsonDir'), DS);
+
+        return $this->parentDirPath ? $dir . DS . implode(DS, $this->parentDirPath) : $dir;
+    }
+
+    /**
+     * パス要素として安全な値か検証する
+     *
+     * @param string $value 検証する値
+     * @param string $name 値の名前
+     * @return void
+     */
+    private function validatePathSegment(string $value, string $name): void
+    {
+        if (
+            trim($value) === ''
+            || str_contains($value, '..')
+            || str_contains($value, '/')
+            || str_contains($value, '\\')
+        ) {
+            throw new InvalidArgumentException("不正なパス要素です: {$name}");
+        }
+    }
+
+    /**
+     * 出力先ディレクトリを作成する
+     *
+     * @return string
+     */
+    private function prepareOutputDir(): string
+    {
+        $baseDir = rtrim((string)Configure::read('App.jsonDir'), DS) . DS;
+        $realBaseDir = realpath($baseDir);
+        if ($realBaseDir === false) {
+            throw new RuntimeException("JSON 出力ディレクトリが存在しません: {$baseDir}");
+        }
+
+        $baseDir = rtrim($realBaseDir, DS) . DS;
+        $dirpath = rtrim($realBaseDir, DS);
+        foreach ($this->parentDirPath as $segment) {
+            $dirpath .= DS . $segment;
+
+            if (is_link($dirpath)) {
+                throw new InvalidArgumentException("出力先にシンボリックリンクは指定できません: {$dirpath}");
+            }
+            if (file_exists($dirpath)) {
+                if (!is_dir($dirpath)) {
+                    throw new InvalidArgumentException("出力先にディレクトリ以外は指定できません: {$dirpath}");
+                }
+            } elseif (!mkdir($dirpath, 0755)) {
+                throw new RuntimeException("ディレクトリ作成に失敗しました: {$dirpath}");
+            }
+
+            $realDirpath = realpath($dirpath);
+            if ($realDirpath === false) {
+                throw new RuntimeException("出力先ディレクトリが存在しません: {$dirpath}");
+            }
+            $realDirpath = rtrim($realDirpath, DS) . DS;
+
+            if (!str_starts_with($realDirpath, $baseDir)) {
+                throw new InvalidArgumentException("JSON 出力ディレクトリ外への出力はできません: {$dirpath}");
+            }
+
+            $dirpath = rtrim($realDirpath, DS);
+        }
+
+        return $dirpath;
     }
 }

--- a/tests/TestCase/Utility/FileBuilderTest.php
+++ b/tests/TestCase/Utility/FileBuilderTest.php
@@ -6,6 +6,7 @@ namespace Gotea\Test\TestCase\Utility;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Gotea\Utility\FileBuilder;
+use InvalidArgumentException;
 
 /**
  * Gotea\Utility\FileBuilder Test Case
@@ -21,11 +22,26 @@ class FileBuilderTest extends TestCase
     {
         $builder = FileBuilder::new();
 
-        $builder->setParentDir('/123');
-        $this->assertStringContainsString('/123', $builder->getDir());
+        $builder->setParentDir('123');
+        $this->assertStringContainsString(DS . '123', $builder->getDir());
 
-        $builder->setParentDir('/hoge/fuga');
-        $this->assertStringContainsString('/hoge/fuga', $builder->getDir());
+        $builder->setParentDir('hoge');
+        $this->assertStringContainsString(DS . 'hoge', $builder->getDir());
+
+        $builder->setParentDirPath('hoge', 'fuga');
+        $this->assertStringContainsString(DS . 'hoge' . DS . 'fuga', $builder->getDir());
+    }
+
+    /**
+     * Test setParentDir method with invalid path segments
+     *
+     * @return void
+     */
+    public function testSetParentDirFailure(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FileBuilder::new()->setParentDir('../123');
     }
 
     /**
@@ -37,15 +53,70 @@ class FileBuilderTest extends TestCase
     {
         $builder = FileBuilder::new();
 
-        // ファイル名にディレクトリセパレータ (/) を含む場合は書き込みに失敗する
-        $this->assertFalse($builder->output('hoge/fuga', 'test'));
-
         $this->assertTrue($builder->output('hoge', 'test'));
         $this->assertTrue(file_exists(Configure::read('App.jsonDir') . DS . 'hoge.json'));
 
         // 親ディレクトリの指定あり
-        $builder->setParentDir('/123');
+        $builder->setParentDir('123');
         $this->assertTrue($builder->output('fuga', 'test'));
-        $this->assertTrue(file_exists(Configure::read('App.jsonDir') . DS . '/123' . DS . 'fuga.json'));
+        $this->assertTrue(file_exists(Configure::read('App.jsonDir') . DS . '123' . DS . 'fuga.json'));
+    }
+
+    /**
+     * Test output method with invalid filenames
+     *
+     * @return void
+     */
+    public function testOutputFailure(): void
+    {
+        $builder = FileBuilder::new();
+
+        $this->assertFalse($builder->output('', 'test'));
+        $this->assertFalse($builder->output(' ', 'test'));
+        $this->assertFalse($builder->output('..', 'test'));
+        $this->assertFalse($builder->output('../hoge', 'test'));
+        $this->assertFalse($builder->output('hoge/fuga', 'test'));
+        $this->assertFalse($builder->output('hoge\\fuga', 'test'));
+    }
+
+    /**
+     * Test output method with symlink parent directory
+     *
+     * @return void
+     */
+    public function testOutputFailureWithSymlinkParentDir(): void
+    {
+        $originalJsonDir = Configure::read('App.jsonDir');
+        $baseDir = TMP . 'file_builder_' . uniqid();
+        $outsideDir = TMP . 'file_builder_outside_' . uniqid();
+        $linkPath = $baseDir . DS . 'ranking';
+
+        mkdir($baseDir);
+        mkdir($outsideDir);
+        if (!symlink($outsideDir, $linkPath)) {
+            rmdir($outsideDir);
+            rmdir($baseDir);
+
+            $this->markTestSkipped('Failed to create symlink.');
+        }
+
+        Configure::write('App.jsonDir', $baseDir);
+        try {
+            $builder = FileBuilder::new()->setParentDirPath('ranking', 'jp');
+
+            $this->assertFalse($builder->output('japan2026', 'test'));
+            $this->assertFalse(file_exists($outsideDir . DS . 'jp'));
+        } finally {
+            Configure::write('App.jsonDir', $originalJsonDir);
+            if (file_exists($linkPath) || is_link($linkPath)) {
+                unlink($linkPath);
+            }
+            if (is_dir($outsideDir)) {
+                rmdir($outsideDir);
+            }
+            if (is_dir($baseDir)) {
+                rmdir($baseDir);
+            }
+        }
     }
 }


### PR DESCRIPTION
### 概要

- FileBuilder の出力パス検証を追加し、意図しないパスへの JSON 出力を防ぎます

### 対応内容

- `filename` / `parentDir` の空文字、`..`、ディレクトリ区切り文字を拒否
- 出力先ディレクトリの実体パスが `App.jsonDir` 配下に収まることを検証
- 複数階層の親ディレクトリ指定用に `setParentDirPath()` を追加
- ranking JSON 出力側を `setParentDirPath('ranking', $countryCode)` に変更
- FileBuilderTest に正常系・異常系を追加

### 確認内容

- `docker compose exec backend ./vendor/bin/phpunit --colors=always tests/TestCase/Utility/FileBuilderTest.php`
- `docker compose exec backend composer cs-check`
- `docker compose exec backend composer test`

Closes #1588
