### PR TITLE
Vue コンポーネントを Composition API へ移行

### DIFF
--- a/resources/assets/scripts/app.ts
+++ b/resources/assets/scripts/app.ts
@@ -1,5 +1,6 @@
-import { defineComponent } from 'vue';
+import { onMounted, ref } from 'vue';
 import axios from 'axios';
+import { useStore } from 'vuex';
 
 import BlockUI from '@/components/parts/BlockUI.vue';
 import Dialog from '@/components/parts/Dialog.vue';
@@ -32,7 +33,7 @@ const changeTab = (element: HTMLElement): void => {
 /**
  * アプリケーションのVueインスタンス
  */
-export default defineComponent({
+export default {
   components: {
     appBlock: BlockUI,
     appModal: Modal,
@@ -45,32 +46,22 @@ export default defineComponent({
     NotificationListPage,
     TableTemplateListPage,
   },
-  data: () => {
-    return {
-      countryId: '',
-      changed: false,
-      historyId: null as number | null,
-      hide: true,
-    };
-  },
-  mounted() {
-    this.setTabEvent();
-    this.setCheckboxEvent();
-    this.setAxiosInterceptor();
-
-    this.hide = false;
-  },
-  methods: {
-    setAxiosInterceptor() {
+  setup() {
+    const store = useStore();
+    const countryId = ref('');
+    const changed = ref(false);
+    const historyId = ref<number | null>(null);
+    const hide = ref(true);
+    const setAxiosInterceptor = () => {
       // リクエスト
       axios.interceptors.request.use(
         (config) => {
           config.headers['Content-Type'] = 'application/json';
-          this.hide = true;
+          hide.value = true;
           return config;
         },
         (error) => {
-          this.hide = false;
+          hide.value = false;
           return Promise.reject(error);
         },
       );
@@ -78,16 +69,16 @@ export default defineComponent({
       // レスポンス
       axios.interceptors.response.use(
         (response) => {
-          this.hide = false;
+          hide.value = false;
           return response;
         },
         (error) => {
-          this.hide = false;
+          hide.value = false;
           return Promise.reject(error.response);
         },
       );
-    },
-    setCheckboxEvent() {
+    };
+    const setCheckboxEvent = () => {
       // チェックボックスと入力項目の連動
       const checked = document.querySelector('[data-checked]') as HTMLInputElement;
       if (checked) {
@@ -110,8 +101,8 @@ export default defineComponent({
         setChecked();
         checked.addEventListener('click', () => setChecked(true), false);
       }
-    },
-    setTabEvent() {
+    };
+    const setTabEvent = () => {
       // タブ押下時
       const tabWrapper = document.querySelector('.tabs');
       if (!tabWrapper) {
@@ -143,33 +134,52 @@ export default defineComponent({
         // 無ければ1つ目
         changeTab(tabs[0] as HTMLInputElement);
       }
-    },
-    changeCountry($event: Event) {
+    };
+    const changeCountry = ($event: Event) => {
       const target = $event.target as HTMLInputElement;
-      this.countryId = target.value;
-      if (!this.changed) {
-        this.changed = true;
+      countryId.value = target.value;
+      if (!changed.value) {
+        changed.value = true;
       }
-    },
-    openModal(url: string, width: string, height: string) {
-      this.$store.dispatch('openModal', {
+    };
+    const openModal = (url: string, width: string, height: string) => {
+      store.dispatch('openModal', {
         url: url,
         width: width,
         height: height,
       });
-    },
-    openDialog(title: string | null, messages: string[], type: string) {
-      this.$store.dispatch('openDialog', {
+    };
+    const openDialog = (title: string | null, messages: string[], type: string) => {
+      store.dispatch('openDialog', {
         title: title,
         messages: messages,
         type: type,
       });
-    },
-    select(historyId: string) {
-      this.historyId = parseInt(historyId, 10);
-    },
-    clearHistory() {
-      this.historyId = 0;
-    },
+    };
+    const select = (value: string) => {
+      historyId.value = parseInt(value, 10);
+    };
+    const clearHistory = () => {
+      historyId.value = 0;
+    };
+
+    onMounted(() => {
+      setTabEvent();
+      setCheckboxEvent();
+      setAxiosInterceptor();
+      hide.value = false;
+    });
+
+    return {
+      changeCountry,
+      clearHistory,
+      hide,
+      historyId,
+      openDialog,
+      openModal,
+      countryId,
+      changed,
+      select,
+    };
   },
-});
+};

--- a/resources/assets/scripts/components/Paginator.vue
+++ b/resources/assets/scripts/components/Paginator.vue
@@ -24,69 +24,55 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed, toRefs } from 'vue';
 
-export default defineComponent({
-  props: {
-    currentPage: {
-      type: Number,
-      default: 1,
-    },
-    perPage: {
-      type: Number,
-      default: 20,
-    },
-    total: {
-      type: Number,
-      default: 1,
-    },
+const props = defineProps({
+  currentPage: {
+    type: Number,
+    default: 1,
   },
-  computed: {
-    isFirstPage(): boolean {
-      return this.currentPage === 1;
-    },
-    isLastPage(): boolean {
-      return this.currentPage === this.lastPage;
-    },
-    pageCount(): number {
-      return Math.min(this.lastPage, 9);
-    },
-    lastPage(): number {
-      return Math.ceil(this.total / this.perPage);
-    },
-    fromPage(): number {
-      if (this.lastPage <= this.pageCount) {
-        return 1;
-      }
-      if (this.currentPage <= 5) {
-        return 1;
-      }
-      // 5ページを起点に足りない後ページ分前ページへ戻す
-      // 現在ページはカウントしないため+1している
-      return 5 - (5 - (this.toPage - this.pageCount + 1));
-    },
-    toPage(): number {
-      if (this.currentPage <= 5) {
-        return this.pageCount;
-      }
-      if (this.currentPage + 4 <= this.lastPage) {
-        return this.currentPage + 4;
-      }
-      return this.lastPage;
-    },
-    pages(): number[] {
-      const pages = [];
-      for (let p = this.fromPage; p <= this.toPage; p++) {
-        pages.push(p);
-      }
-      return pages;
-    },
+  perPage: {
+    type: Number,
+    default: 20,
   },
-  methods: {
-    onChangePage(page: number): void {
-      this.$emit('change-page', page);
-    },
+  total: {
+    type: Number,
+    default: 1,
   },
 });
+const { currentPage, perPage, total } = toRefs(props);
+const emit = defineEmits<{ 'change-page': [page: number] }>();
+const lastPage = computed(() => Math.ceil(total.value / perPage.value));
+const pageCount = computed(() => Math.min(lastPage.value, 9));
+const isFirstPage = computed(() => currentPage.value === 1);
+const isLastPage = computed(() => currentPage.value === lastPage.value);
+const toPage = computed(() => {
+  if (currentPage.value <= 5) {
+    return pageCount.value;
+  }
+  if (currentPage.value + 4 <= lastPage.value) {
+    return currentPage.value + 4;
+  }
+  return lastPage.value;
+});
+const fromPage = computed(() => {
+  if (lastPage.value <= pageCount.value) {
+    return 1;
+  }
+  if (currentPage.value <= 5) {
+    return 1;
+  }
+  // 5ページを起点に足りない後ページ分前ページへ戻す
+  // 現在ページはカウントしないため+1している
+  return 5 - (5 - (toPage.value - pageCount.value + 1));
+});
+const pages = computed(() => {
+  const pages: number[] = [];
+  for (let p = fromPage.value; p <= toPage.value; p++) {
+    pages.push(p);
+  }
+  return pages;
+});
+const onChangePage = (page: number): void => emit('change-page', page);
 </script>

--- a/resources/assets/scripts/components/notifications/Item.vue
+++ b/resources/assets/scripts/components/notifications/Item.vue
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 import dayjs from 'dayjs';
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 import type { PropType } from 'vue';
 import { Notification as Item } from '@/types/notification';
 

--- a/resources/assets/scripts/components/parts/BlockUI.vue
+++ b/resources/assets/scripts/components/parts/BlockUI.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 
 const props = defineProps({
   hide: {

--- a/resources/assets/scripts/components/parts/Dialog.vue
+++ b/resources/assets/scripts/components/parts/Dialog.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineProps, nextTick, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import type { PropType } from 'vue';
 import { DialogOption } from '@/types';

--- a/resources/assets/scripts/components/parts/Tab.vue
+++ b/resources/assets/scripts/components/parts/Tab.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps, onMounted } from 'vue';
+import { onMounted } from 'vue';
 import type { PropType } from 'vue';
 
 let selectTab = '';

--- a/resources/assets/scripts/components/players/Button.vue
+++ b/resources/assets/scripts/components/players/Button.vue
@@ -4,42 +4,30 @@
   </button>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useStore } from 'vuex';
 
-export default defineComponent({
-  props: {
-    url: {
-      type: String,
-      required: true,
-    },
-    countryId: {
-      type: String,
-      required: true,
-    },
-    paramId: {
-      type: String,
-      required: true,
-    },
-    changed: {
-      type: Boolean,
-      default: false,
-    },
+const props = defineProps({
+  url: {
+    type: String,
+    required: true,
   },
-  computed: {
-    targetId(): string {
-      if (!this.changed) {
-        return this.paramId;
-      }
-      return this.countryId;
-    },
+  countryId: {
+    type: String,
+    required: true,
   },
-  methods: {
-    newPlayer() {
-      this.$store.dispatch('openModal', {
-        url: `${this.url}?country_id=${this.targetId}`,
-      });
-    },
+  paramId: {
+    type: String,
+    required: true,
+  },
+  changed: {
+    type: Boolean,
+    default: false,
   },
 });
+const store = useStore();
+const targetId = computed(() => (props.changed ? props.countryId : props.paramId));
+const newPlayer = () =>
+  store.dispatch('openModal', { url: `${props.url}?country_id=${targetId.value}` });
 </script>

--- a/resources/assets/scripts/components/ranking/Header.vue
+++ b/resources/assets/scripts/components/ranking/Header.vue
@@ -90,103 +90,84 @@
   </ul>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, toRefs } from 'vue';
 import axios from 'axios';
 
 import { Country, DropDown, Year } from '@/types';
 
-export default defineComponent({
-  props: {
-    isAdmin: {
-      type: Boolean,
-      default: false,
-    },
-    lastUpdate: {
-      type: String,
-      default: '',
-    },
+const props = defineProps({
+  isAdmin: {
+    type: Boolean,
+    default: false,
   },
-  data: () => {
-    return {
-      countries: [] as DropDown[],
-      years: [] as DropDown[],
-      select: {
-        year: '',
-        country: '',
-        limit: 0,
-        from: '',
-        to: '',
-        type: 'point',
-      },
-    };
-  },
-  computed: {
-    limits() {
-      const limits = [];
-      for (let l = 20; l <= 50; l = l + 10) {
-        limits.push({
-          value: l,
-          text: `～${l}位`,
-        });
-      }
-      return limits;
-    },
-    types() {
-      return [
-        {
-          value: 'point',
-          text: '勝数',
-        },
-        {
-          value: 'percent',
-          text: '勝率',
-        },
-      ];
-    },
-  },
-  mounted() {
-    // 所属国
-    Promise.all([axios.get('/api/countries'), axios.get('/api/years')])
-      .then((res) => {
-        this.countries = res[0].data.response.map((obj: Country) => ({
-          value: obj.code,
-          text: `${obj.name}棋戦`,
-        }));
-        this.years = res[1].data.response.map((obj: Year) => ({
-          value: obj.year,
-          text: `${obj.year}年度`,
-          old: obj.old,
-        }));
-      })
-      .then(() => {
-        this.select.year = this.years[0].value.toString();
-        this.select.country = this.countries[0].value.toString() || '';
-        this.select.limit = this.limits[0].value;
-        this.search();
-      });
-  },
-  methods: {
-    changeValue($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      this.select[target.name] = target.value;
-      this.search();
-    },
-    search() {
-      this.$emit('search', this.select);
-    },
-    clearDate() {
-      this.select.from = '';
-      this.select.to = '';
-      this.search();
-    },
-    json() {
-      this.$emit('json', this.select);
-    },
-    useInputDate() {
-      const selected = this.years.find((y) => y.value === parseInt(this.select.year, 10));
-      return selected ? !selected.old : false;
-    },
+  lastUpdate: {
+    type: String,
+    default: '',
   },
 });
+const { isAdmin, lastUpdate } = toRefs(props);
+const emit = defineEmits<{ search: [value: typeof select]; json: [value: typeof select] }>();
+const countries = ref<DropDown[]>([]);
+const years = ref<DropDown[]>([]);
+const select = reactive({ year: '', country: '', limit: 0, from: '', to: '', type: 'point' });
+const limits = computed(() => {
+  const values = [];
+  for (let l = 20; l <= 50; l += 10) {
+    values.push({
+      value: l,
+      text: `～${l}位`,
+    });
+  }
+  return values;
+});
+const types = computed(() => {
+  return [
+    {
+      value: 'point',
+      text: '勝数',
+    },
+    {
+      value: 'percent',
+      text: '勝率',
+    },
+  ];
+});
+const search = () => emit('search', select);
+onMounted(() => {
+  // 所属国
+  Promise.all([axios.get('/api/countries'), axios.get('/api/years')])
+    .then((res) => {
+      countries.value = res[0].data.response.map((obj: Country) => ({
+        value: obj.code,
+        text: `${obj.name}棋戦`,
+      }));
+      years.value = res[1].data.response.map((obj: Year) => ({
+        value: obj.year,
+        text: `${obj.year}年度`,
+        old: obj.old,
+      }));
+    })
+    .then(() => {
+      select.year = years.value[0].value.toString();
+      select.country = countries.value[0].value.toString() || '';
+      select.limit = limits.value[0].value;
+      search();
+    });
+});
+const changeValue = ($event: Event) => {
+  const target = $event.target as HTMLInputElement;
+  (select as Record<string, string | number>)[target.name] = target.value;
+  search();
+};
+const clearDate = () => {
+  select.from = '';
+  select.to = '';
+  search();
+};
+const json = () => emit('json', select);
+const useInputDate = () => {
+  const selected = years.value.find((y) => y.value === parseInt(select.year, 10));
+  return selected ? !selected.old : false;
+};
 </script>

--- a/resources/assets/scripts/components/ranking/Index.vue
+++ b/resources/assets/scripts/components/ranking/Index.vue
@@ -10,8 +10,9 @@
   </section>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref, toRefs } from 'vue';
+import { useStore } from 'vuex';
 import axios from 'axios';
 import dayjs from 'dayjs';
 
@@ -19,66 +20,55 @@ import RankingHeader from '@/components/ranking/Header.vue';
 import RankingItems from '@/components/ranking/Items.vue';
 import { RankingCondition } from '@/types/ranking';
 
-export default defineComponent({
-  components: {
-    RankingHeader,
-    RankingItems,
-  },
-  props: {
-    isAdmin: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  data: () => {
-    return {
-      lastUpdate: '',
-      items: [],
-    };
-  },
-  methods: {
-    onSearch(_params: RankingCondition) {
-      const params = {
-        from: _params.from || '',
-        to: _params.to || '',
-        type: _params.type,
-      };
-
-      axios.get(this.createUrl(_params), { params: params }).then((res) => {
-        const json = res.data.response;
-        if (json.lastUpdate) {
-          const dateObj = dayjs(json.lastUpdate);
-          this.lastUpdate = dateObj.format('YYYY年MM月DD日');
-        } else {
-          this.lastUpdate = '';
-        }
-        this.items = json.ranking;
-      });
-    },
-    outputJson(_params: RankingCondition) {
-      const params = {
-        from: _params.from || '',
-        to: _params.to || '',
-        type: _params.type,
-      };
-
-      axios
-        .post(this.createUrl(_params), params)
-        .then(() =>
-          this.$store.dispatch('openDialog', {
-            messages: 'JSONを出力しました。',
-          }),
-        )
-        .catch(() =>
-          this.$store.dispatch('openDialog', {
-            messages: 'JSON出力に失敗しました…。',
-            type: 'error',
-          }),
-        );
-    },
-    createUrl(_params: RankingCondition) {
-      return `/api/players/ranking/${_params.country}/${_params.year}/${_params.limit}`;
-    },
+const props = defineProps({
+  isAdmin: {
+    type: Boolean,
+    default: false,
   },
 });
+const { isAdmin } = toRefs(props);
+const store = useStore();
+const lastUpdate = ref('');
+const items = ref([]);
+const createUrl = (_params: RankingCondition) =>
+  `/api/players/ranking/${_params.country}/${_params.year}/${_params.limit}`;
+const onSearch = (_params: RankingCondition) => {
+  const params = {
+    from: _params.from || '',
+    to: _params.to || '',
+    type: _params.type,
+  };
+
+  axios.get(createUrl(_params), { params: params }).then((res) => {
+    const json = res.data.response;
+    if (json.lastUpdate) {
+      const dateObj = dayjs(json.lastUpdate);
+      lastUpdate.value = dateObj.format('YYYY年MM月DD日');
+    } else {
+      lastUpdate.value = '';
+    }
+    items.value = json.ranking;
+  });
+};
+const outputJson = (_params: RankingCondition) => {
+  const params = {
+    from: _params.from || '',
+    to: _params.to || '',
+    type: _params.type,
+  };
+
+  axios
+    .post(createUrl(_params), params)
+    .then(() =>
+      store.dispatch('openDialog', {
+        messages: 'JSONを出力しました。',
+      }),
+    )
+    .catch(() =>
+      store.dispatch('openDialog', {
+        messages: 'JSON出力に失敗しました…。',
+        type: 'error',
+      }),
+    );
+};
 </script>

--- a/resources/assets/scripts/components/ranking/Items.vue
+++ b/resources/assets/scripts/components/ranking/Items.vue
@@ -32,34 +32,31 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { PropType, toRefs } from 'vue';
+import { useStore } from 'vuex';
 
 import { RankingResultItem } from '@/types/ranking';
 
-export default defineComponent({
-  props: {
-    items: {
-      type: Array as PropType<RankingResultItem[]>,
-      default: () => [],
-    },
-  },
-  methods: {
-    getRank(_idx: number, _row: RankingResultItem) {
-      if (this.items[_idx - 1]) {
-        const beforeRank = this.items[_idx - 1].rank;
-        return _row.rank === beforeRank ? '' : `${_row.rank}`;
-      }
-      return _row.rank;
-    },
-    getSexClass(_row: RankingResultItem) {
-      return _row.sex === '女性' ? 'female' : 'male';
-    },
-    select(_row: RankingResultItem) {
-      this.$store.dispatch('openModal', {
-        url: _row.url,
-      });
-    },
+const props = defineProps({
+  items: {
+    type: Array as PropType<RankingResultItem[]>,
+    default: () => [],
   },
 });
+const { items } = toRefs(props);
+const store = useStore();
+const getRank = (_idx: number, _row: RankingResultItem) => {
+  if (props.items[_idx - 1]) {
+    const beforeRank = props.items[_idx - 1].rank;
+    return _row.rank === beforeRank ? '' : `${_row.rank}`;
+  }
+  return _row.rank;
+};
+const getSexClass = (_row: RankingResultItem) => (_row.sex === '女性' ? 'female' : 'male');
+const select = (_row: RankingResultItem) => {
+  store.dispatch('openModal', {
+    url: _row.url,
+  });
+};
 </script>

--- a/resources/assets/scripts/components/ranks/Header.vue
+++ b/resources/assets/scripts/components/ranks/Header.vue
@@ -16,43 +16,34 @@
   </ul>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
 import axios from 'axios';
 
 import { Country, DropDown } from '@/types';
 
-export default defineComponent({
-  data: () => {
-    return {
-      countries: [] as DropDown[],
-      selectedCountry: '',
-    };
-  },
-  mounted() {
-    axios
-      .get('/api/countries/?has_title=1')
-      .then((res) =>
-        res.data.response.map((obj: Country) => ({
-          value: obj.id,
-          text: obj.name,
-        })),
-      )
-      .then((countries) => {
-        this.countries = countries;
-        this.selectedCountry = this.countries[0].value.toString() || '';
-        this.search();
-      });
-  },
-  methods: {
-    changeValue($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      this.selectedCountry = target.value;
-      this.search();
-    },
-    search() {
-      this.$emit('search', { country: this.selectedCountry });
-    },
-  },
+const emit = defineEmits<{ search: [params: { country: string }] }>();
+const countries = ref<DropDown[]>([]);
+const selectedCountry = ref('');
+const search = () => emit('search', { country: selectedCountry.value });
+onMounted(() => {
+  axios
+    .get('/api/countries/?has_title=1')
+    .then((res) =>
+      res.data.response.map((obj: Country) => ({
+        value: obj.id,
+        text: obj.name,
+      })),
+    )
+    .then((countryOptions) => {
+      countries.value = countryOptions;
+      selectedCountry.value = countries.value[0].value.toString() || '';
+      search();
+    });
 });
+const changeValue = ($event: Event) => {
+  const target = $event.target as HTMLInputElement;
+  selectedCountry.value = target.value;
+  search();
+};
 </script>

--- a/resources/assets/scripts/components/ranks/Index.vue
+++ b/resources/assets/scripts/components/ranks/Index.vue
@@ -5,30 +5,18 @@
   </section>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 import axios from 'axios';
 
 import RanksHeader from '@/components/ranks/Header.vue';
 import RanksItems from '@/components/ranks/Items.vue';
 import { RanksCondition } from '@/types/ranks';
 
-export default defineComponent({
-  components: {
-    RanksHeader,
-    RanksItems,
-  },
-  data: () => {
-    return {
-      items: [],
-    };
-  },
-  methods: {
-    onSearch(_params: RanksCondition) {
-      axios
-        .get(`/api/players/ranks/${_params.country}`)
-        .then((res) => (this.items = res.data.response));
-    },
-  },
-});
+const items = ref([]);
+const onSearch = (_params: RanksCondition) => {
+  axios
+    .get(`/api/players/ranks/${_params.country}`)
+    .then((res) => (items.value = res.data.response));
+};
 </script>

--- a/resources/assets/scripts/components/ranks/Items.vue
+++ b/resources/assets/scripts/components/ranks/Items.vue
@@ -15,22 +15,17 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { PropType, toRefs } from 'vue';
 
 import { RanksItem } from '@/types/ranks';
 
-export default defineComponent({
-  props: {
-    items: {
-      type: Array as PropType<RanksItem[]>,
-      default: () => [],
-    },
-  },
-  methods: {
-    count(_item: RanksItem) {
-      return `${_item.count}人`;
-    },
+const props = defineProps({
+  items: {
+    type: Array as PropType<RanksItem[]>,
+    default: () => [],
   },
 });
+const { items } = toRefs(props);
+const count = (_item: RanksItem) => `${_item.count}人`;
 </script>

--- a/resources/assets/scripts/components/table-templates/Item.vue
+++ b/resources/assets/scripts/components/table-templates/Item.vue
@@ -22,7 +22,7 @@
 
 <script setup lang="ts">
 import dayjs from 'dayjs';
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 import type { PropType } from 'vue';
 import { TableTemplate as Item } from '@/types/table-template';
 

--- a/resources/assets/scripts/components/titles/AddHistory.vue
+++ b/resources/assets/scripts/components/titles/AddHistory.vue
@@ -152,156 +152,164 @@
   </ul>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed, onMounted, reactive, toRefs, watch } from 'vue';
+import { useStore } from 'vuex';
 import axios from 'axios';
 
 import { Player } from '@/types/titles';
 import { Country } from '@/types';
 
-export default defineComponent({
-  props: {
-    isTeam: {
-      type: Boolean,
-      default: false,
-    },
-    historyId: {
-      type: Number,
-      default: null,
-    },
+const props = defineProps({
+  isTeam: {
+    type: Boolean,
+    default: false,
   },
-  data: () => {
-    return {
-      countries: [] as Country[],
-      edit: false,
-      viewName: '',
-      year: '' as number | string,
-      holding: '' as number | string,
-      acquired: '',
-      broadcasted: '',
-      isOfficial: true,
-      name: '',
-      playerId: null as number | null,
-      countryId: null as number | null,
-      teamName: null,
-      isTeamHidden: '',
-      players: [] as Player[],
-    };
-  },
-  computed: {
-    key(): string | number | null {
-      return this.isTeam ? this.teamName : this.playerId;
-    },
-    text(): string {
-      return this.edit ? '編集' : '新規登録';
-    },
-    required(): boolean {
-      return !(!!this.year && !!this.holding && !!this.acquired && !!this.key);
-    },
-    initialViewName(): string {
-      return '（検索エリアから棋士を検索してください。）';
-    },
-  },
-  watch: {
-    historyId(_value: number) {
-      if (_value) {
-        axios.get(`/api/histories/${_value}`).then((res) => {
-          const json = res.data.response;
-          this.isTeamHidden = this.getTeamHidden(json.isTeam);
-          this.playerId = json.playerId;
-          this.holding = json.holding;
-          this.countryId = json.countryId;
-          this.year = json.targetYear;
-          this.acquired = json.acquired;
-          this.isOfficial = json.isOfficial;
-          this.broadcasted = json.broadcasted;
-          this.viewName = json.winPlayerName;
-          this.teamName = json.winGroupName;
-          this.edit = true;
-        });
-      }
-    },
-  },
-  mounted() {
-    this.viewName = this.initialViewName;
-    this.isTeamHidden = this.getTeamHidden(this.isTeam);
-    axios.get('/api/countries/').then((res) => (this.countries = res.data.response));
-  },
-  methods: {
-    changeCountry($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      this.countryId = Number(target.value);
-    },
-    getTeamHidden(value: boolean) {
-      return value ? '1' : '';
-    },
-    search() {
-      if (this.name === '') {
-        this.$store.dispatch('openDialog', {
-          messages: '棋士名は必須です。',
-          type: 'error',
-        });
-        return;
-      }
-
-      axios
-        .post('/api/players', {
-          name: this.name,
-        })
-        .then((res) => {
-          const players = res.data.response.results;
-          switch (players.length) {
-            case 0:
-              this.$store.dispatch('openDialog', {
-                messages: '検索結果が0件でした。',
-                type: 'warning',
-              });
-              break;
-            case 1:
-              this.select(players[0]);
-              break;
-            default:
-              this.players = players;
-              break;
-          }
-        })
-        .catch((res) => {
-          const message = res.data.response.message;
-          this.$store.dispatch('openDialog', {
-            messages: message || '更新に失敗しました…。',
-            type: 'error',
-          });
-        });
-    },
-    getName(player: Player) {
-      if (player.nameOther) {
-        return `${player.name} [${player.nameOther}]`;
-      }
-      return player.name;
-    },
-    select(player: Player) {
-      this.playerId = player.id || null;
-      this.countryId = player.countryId || null;
-      this.viewName = `${player.name} ${player.rankName}`;
-      this.name = '';
-      this.players = [];
-    },
-    clearData() {
-      this.viewName = this.initialViewName;
-      this.isTeamHidden = this.getTeamHidden(this.isTeam);
-      this.year = '';
-      this.holding = '';
-      this.acquired = '';
-      this.isOfficial = true;
-      this.broadcasted = '';
-      this.name = '';
-      this.playerId = null;
-      this.countryId = null;
-      this.teamName = null;
-      this.players = [];
-      this.edit = false;
-      this.$emit('cleared');
-    },
+  historyId: {
+    type: Number,
+    default: null,
   },
 });
+const { isTeam, historyId } = toRefs(props);
+const emit = defineEmits<{ cleared: [] }>();
+const store = useStore();
+const state = reactive({
+  countries: [] as Country[],
+  edit: false,
+  viewName: '',
+  year: '' as number | string,
+  holding: '' as number | string,
+  acquired: '',
+  broadcasted: '',
+  isOfficial: true,
+  name: '',
+  playerId: null as number | null,
+  countryId: null as number | null,
+  teamName: null,
+  isTeamHidden: '',
+  players: [] as Player[],
+});
+const {
+  countries,
+  edit,
+  viewName,
+  year,
+  holding,
+  acquired,
+  broadcasted,
+  isOfficial,
+  name,
+  playerId,
+  countryId,
+  teamName,
+  isTeamHidden,
+  players,
+} = toRefs(state);
+const key = computed(() => (props.isTeam ? state.teamName : state.playerId));
+const text = computed(() => (state.edit ? '編集' : '新規登録'));
+const required = computed(
+  () => !(!!state.year && !!state.holding && !!state.acquired && !!key.value),
+);
+const initialViewName = '（検索エリアから棋士を検索してください。）';
+const getTeamHidden = (value: boolean) => (value ? '1' : '');
+const loadHistory = (value: number | null) => {
+  if (value) {
+    axios.get(`/api/histories/${value}`).then((res) => {
+      const json = res.data.response;
+      Object.assign(state, {
+        isTeamHidden: getTeamHidden(json.isTeam),
+        playerId: json.playerId,
+        holding: json.holding,
+        countryId: json.countryId,
+        year: json.targetYear,
+        acquired: json.acquired,
+        isOfficial: json.isOfficial,
+        broadcasted: json.broadcasted,
+        viewName: json.winPlayerName,
+        teamName: json.winGroupName,
+        edit: true,
+      });
+    });
+  }
+};
+watch(historyId, loadHistory);
+onMounted(() => {
+  state.viewName = initialViewName;
+  state.isTeamHidden = getTeamHidden(props.isTeam);
+  axios.get('/api/countries/').then((res) => (state.countries = res.data.response));
+  loadHistory(props.historyId);
+});
+const changeCountry = ($event: Event) => {
+  const target = $event.target as HTMLInputElement;
+  state.countryId = Number(target.value);
+};
+const search = () => {
+  if (state.name === '') {
+    store.dispatch('openDialog', {
+      messages: '棋士名は必須です。',
+      type: 'error',
+    });
+    return;
+  }
+
+  axios
+    .post('/api/players', {
+      name: state.name,
+    })
+    .then((res) => {
+      const players = res.data.response.results;
+      switch (players.length) {
+        case 0:
+          store.dispatch('openDialog', {
+            messages: '検索結果が0件でした。',
+            type: 'warning',
+          });
+          break;
+        case 1:
+          select(players[0]);
+          break;
+        default:
+          state.players = players;
+          break;
+      }
+    })
+    .catch((res) => {
+      const message = res.data.response.message;
+      store.dispatch('openDialog', {
+        messages: message || '更新に失敗しました…。',
+        type: 'error',
+      });
+    });
+};
+const getName = (player: Player) => {
+  if (player.nameOther) {
+    return `${player.name} [${player.nameOther}]`;
+  }
+  return player.name;
+};
+const select = (player: Player) => {
+  state.playerId = player.id || null;
+  state.countryId = player.countryId || null;
+  state.viewName = `${player.name} ${player.rankName}`;
+  state.name = '';
+  state.players = [];
+};
+const clearData = () => {
+  Object.assign(state, {
+    viewName: initialViewName,
+    isTeamHidden: getTeamHidden(props.isTeam),
+    year: '',
+    holding: '',
+    acquired: '',
+    isOfficial: true,
+    broadcasted: '',
+    name: '',
+    playerId: null,
+    countryId: null,
+    teamName: null,
+    players: [],
+    edit: false,
+  });
+  emit('cleared');
+};
 </script>

--- a/resources/assets/scripts/components/titles/Header.vue
+++ b/resources/assets/scripts/components/titles/Header.vue
@@ -46,89 +46,72 @@
   </ul>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, toRefs } from 'vue';
 import axios from 'axios';
 
 import { Country, DropDown } from '@/types';
 
-export default defineComponent({
-  props: {
-    isAdmin: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  data: () => {
-    return {
-      countries: [] as DropDown[],
-      select: {
-        countryId: '',
-        searchClosed: 0,
-        searchNonOutput: 1,
-      },
-    };
-  },
-  computed: {
-    searchNonOutputOptions() {
-      return [
-        {
-          value: 0,
-          text: '含めない',
-        },
-        {
-          value: 1,
-          text: '含める',
-        },
-      ];
-    },
-    searchClosedOptions() {
-      return [
-        {
-          value: 1,
-          text: '検索する',
-        },
-        {
-          value: 0,
-          text: '検索しない',
-        },
-      ];
-    },
-  },
-  mounted() {
-    axios
-      .get('/api/countries/')
-      .then((res) =>
-        res.data.response.map((obj: Country) => ({
-          value: obj.id,
-          text: `${obj.name}棋戦`,
-        })),
-      )
-      .then((countries) => {
-        this.countries = countries;
-        this.select = {
-          countryId: this.countries[0].value.toString() || '',
-          searchNonOutput: this.searchNonOutputOptions[0].value,
-          searchClosed: this.searchClosedOptions[0].value,
-        };
-        this.search();
-      });
-  },
-  methods: {
-    changeValue($event: Event) {
-      const target = $event.target as HTMLInputElement;
-      this.select[target.name] = target.value;
-      this.search();
-    },
-    search() {
-      this.$emit('search', this.select);
-    },
-    add() {
-      this.$emit('add', this.select);
-    },
-    json() {
-      this.$emit('json', this.select);
-    },
-  },
+const props = defineProps({
+  isAdmin: { type: Boolean, default: false },
 });
+const { isAdmin } = toRefs(props);
+const emit = defineEmits<{
+  search: [value: typeof select];
+  add: [value: typeof select];
+  json: [value: typeof select];
+}>();
+const countries = ref<DropDown[]>([]);
+const select = reactive({ countryId: '', searchClosed: 0, searchNonOutput: 1 });
+const searchNonOutputOptions = computed(() => {
+  return [
+    {
+      value: 0,
+      text: '含めない',
+    },
+    {
+      value: 1,
+      text: '含める',
+    },
+  ];
+});
+const searchClosedOptions = computed(() => {
+  return [
+    {
+      value: 1,
+      text: '検索する',
+    },
+    {
+      value: 0,
+      text: '検索しない',
+    },
+  ];
+});
+onMounted(() => {
+  axios
+    .get('/api/countries/')
+    .then((res) =>
+      res.data.response.map((obj: Country) => ({
+        value: obj.id,
+        text: `${obj.name}棋戦`,
+      })),
+    )
+    .then((countryOptions) => {
+      countries.value = countryOptions;
+      Object.assign(select, {
+        countryId: countries.value[0].value.toString() || '',
+        searchNonOutput: searchNonOutputOptions.value[0].value,
+        searchClosed: searchClosedOptions.value[0].value,
+      });
+      search();
+    });
+});
+const changeValue = ($event: Event) => {
+  const target = $event.target as HTMLInputElement;
+  (select as Record<string, string | number>)[target.name] = target.value;
+  search();
+};
+const search = () => emit('search', select);
+const add = () => emit('add', select);
+const json = () => emit('json', select);
 </script>

--- a/resources/assets/scripts/components/titles/Index.vue
+++ b/resources/assets/scripts/components/titles/Index.vue
@@ -33,86 +33,77 @@
   </section>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref, toRefs } from 'vue';
+import { useStore } from 'vuex';
 import axios from 'axios';
 
-import Header from '@/components/titles/Header.vue';
-import Item from '@/components/titles/Item.vue';
+import TitleHeader from '@/components/titles/Header.vue';
+import TitleItem from '@/components/titles/Item.vue';
 import { ModalOption } from '@/types';
 import { TitleCondition, TitleResultItem } from '@/types/titles';
 
-export default defineComponent({
-  components: {
-    titleHeader: Header,
-    titleItem: Item,
-  },
-  props: {
-    isAdmin: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  data: () => {
-    return {
-      params: {},
-      items: [] as TitleResultItem[],
-    };
-  },
-  methods: {
-    onSearch(params: TitleCondition) {
-      this.params = {
-        country_id: params.countryId,
-        search_non_output: params.searchNonOutput,
-        search_closed: params.searchClosed,
-      };
-      this.refresh();
-    },
-    addRow(params: TitleCondition) {
-      this.items.push({
-        id: null,
-        countryId: params.countryId,
-        holding: 1,
-        name: '',
-        sortOrder: this.items.length + 1,
-        winnerName: null,
-        htmlFileName: '',
-        htmlFileHolding: null,
-        htmlFileModified: '',
-        url: null,
-        isClosed: false,
-        isOutput: true,
-        isOfficial: true,
-      });
-    },
-    outputJson() {
-      return axios
-        .post('/api/titles/news')
-        .then(() =>
-          this.$store.dispatch('openDialog', {
-            messages: 'JSONを出力しました。',
-          }),
-        )
-        .catch(() =>
-          this.$store.dispatch('openDialog', {
-            messages: 'JSON出力に失敗しました…。',
-            type: 'error',
-          }),
-        );
-    },
-    openWithCallback(options: ModalOption) {
-      this.$store.dispatch(
-        'openModal',
-        Object.assign(options, {
-          callback: () => this.refresh(),
-        }),
-      );
-    },
-    refresh() {
-      return axios
-        .get('/api/titles', { params: this.params })
-        .then((res) => (this.items = res.data.response));
-    },
+const props = defineProps({
+  isAdmin: {
+    type: Boolean,
+    default: false,
   },
 });
+const { isAdmin } = toRefs(props);
+const store = useStore();
+const params = ref<Record<string, string | number>>({});
+const items = ref<TitleResultItem[]>([]);
+const onSearch = (condition: TitleCondition) => {
+  params.value = {
+    country_id: condition.countryId,
+    search_non_output: condition.searchNonOutput,
+    search_closed: condition.searchClosed,
+  };
+  refresh();
+};
+const addRow = (params: TitleCondition) => {
+  items.value.push({
+    id: null,
+    countryId: params.countryId,
+    holding: 1,
+    name: '',
+    sortOrder: items.value.length + 1,
+    winnerName: null,
+    htmlFileName: '',
+    htmlFileHolding: null,
+    htmlFileModified: '',
+    url: null,
+    isClosed: false,
+    isOutput: true,
+    isOfficial: true,
+  });
+};
+const outputJson = () => {
+  return axios
+    .post('/api/titles/news')
+    .then(() =>
+      store.dispatch('openDialog', {
+        messages: 'JSONを出力しました。',
+      }),
+    )
+    .catch(() =>
+      store.dispatch('openDialog', {
+        messages: 'JSON出力に失敗しました…。',
+        type: 'error',
+      }),
+    );
+};
+const openWithCallback = (options: ModalOption) => {
+  store.dispatch(
+    'openModal',
+    Object.assign(options, {
+      callback: () => refresh(),
+    }),
+  );
+};
+const refresh = () => {
+  return axios
+    .get('/api/titles', { params: params.value })
+    .then((res) => (items.value = res.data.response));
+};
 </script>

--- a/resources/assets/scripts/components/titles/Item.vue
+++ b/resources/assets/scripts/components/titles/Item.vue
@@ -71,6 +71,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, toRefs, watch } from 'vue';
+import type { PropType } from 'vue';
 import { useStore } from 'vuex';
 import axios from 'axios';
 

--- a/resources/assets/scripts/components/titles/Item.vue
+++ b/resources/assets/scripts/components/titles/Item.vue
@@ -69,95 +69,72 @@
   </li>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed, onMounted, ref, toRefs, watch } from 'vue';
+import { useStore } from 'vuex';
 import axios from 'axios';
 
 import { TitleResultItem } from '@/types/titles';
 
-export default defineComponent({
-  props: {
-    isAdmin: {
-      type: Boolean,
-      default: false,
-    },
-    item: {
-      type: Object as PropType<TitleResultItem>,
-      required: true,
-    },
+const props = defineProps({
+  isAdmin: {
+    type: Boolean,
+    default: false,
   },
-  data: () => {
-    return {
-      localItem: {} as TitleResultItem,
-    };
-  },
-  computed: {
-    winnerName(): string {
-      return this.localItem.winnerName || '';
-    },
-    rowClass(): string {
-      return this.localItem.isClosed ? 'table-row-closed' : '';
-    },
-    label(): string {
-      return this.isSaved ? '開く' : '登録';
-    },
-    isSaved(): boolean {
-      return this.localItem.id !== null && this.localItem.id !== undefined;
-    },
-  },
-  watch: {
-    item(newVal) {
-      this.localItem = newVal;
-    },
-  },
-  mounted() {
-    this.localItem = this.item;
-  },
-  methods: {
-    save() {
-      // 未登録なら何もしない
-      if (!this.isSaved) {
-        return;
-      }
-      // 更新処理
-      return axios.put(`/api/titles/${this.localItem.id}`, this.item).catch((res) => {
-        const message = res.data.response.message;
-        this.$store.dispatch('openDialog', {
-          messages: message || '更新に失敗しました…。',
-          type: 'error',
-        });
-      });
-    },
-    select() {
-      if (!this.isSaved) {
-        this.add();
-      } else {
-        this.$emit('openModal', {
-          url: this.localItem.url,
-        });
-      }
-    },
-    add() {
-      // 登録処理
-      return axios
-        .post('/api/titles/', this.item)
-        .then(() => {
-          this.$emit('refresh');
-          this.$store.dispatch('openDialog', {
-            messages: `タイトル【${this.localItem.name}】を登録しました。`,
-          });
-        })
-        .catch((res) => {
-          const message = res.data.response.message;
-          this.$store.dispatch('openDialog', {
-            messages: message || '登録に失敗しました…。',
-            type: 'error',
-          });
-        });
-    },
-    onChangeHtmlFileModified() {
-      this.save();
-    },
+  item: {
+    type: Object as PropType<TitleResultItem>,
+    required: true,
   },
 });
+const { isAdmin, item } = toRefs(props);
+const emit = defineEmits<{ openModal: [options: { url: string | null }]; refresh: [] }>();
+const store = useStore();
+const localItem = ref<TitleResultItem>(item.value);
+const winnerName = computed(() => localItem.value.winnerName || '');
+const rowClass = computed(() => (localItem.value.isClosed ? 'table-row-closed' : ''));
+const isSaved = computed(() => localItem.value.id !== null && localItem.value.id !== undefined);
+const label = computed(() => (isSaved.value ? '開く' : '登録'));
+watch(item, (newVal) => (localItem.value = newVal));
+const save = () => {
+  // 未登録なら何もしない
+  if (!isSaved.value) {
+    return;
+  }
+  // 更新処理
+  return axios.put(`/api/titles/${localItem.value.id}`, props.item).catch((res) => {
+    const message = res.data.response.message;
+    store.dispatch('openDialog', {
+      messages: message || '更新に失敗しました…。',
+      type: 'error',
+    });
+  });
+};
+const select = () => {
+  if (!isSaved.value) {
+    add();
+  } else {
+    emit('openModal', {
+      url: localItem.value.url,
+    });
+  }
+};
+const add = () => {
+  // 登録処理
+  return axios
+    .post('/api/titles/', props.item)
+    .then(() => {
+      emit('refresh');
+      store.dispatch('openDialog', {
+        messages: `タイトル【${localItem.value.name}】を登録しました。`,
+      });
+    })
+    .catch((res) => {
+      const message = res.data.response.message;
+      store.dispatch('openDialog', {
+        messages: message || '登録に失敗しました…。',
+        type: 'error',
+      });
+    });
+};
+const onChangeHtmlFileModified = () => save();
 </script>

--- a/resources/assets/scripts/pages/notifications/index.vue
+++ b/resources/assets/scripts/pages/notifications/index.vue
@@ -32,9 +32,9 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import axios from 'axios';
-import { defineComponent } from 'vue';
+import { onMounted, onBeforeUnmount, ref, toRefs } from 'vue';
 
 import Paginator from '@/components/Paginator.vue';
 import ListItem from '@/components/notifications/Item.vue';
@@ -45,53 +45,44 @@ import {
   readPaginationFromUrl,
 } from '@/libs/pagination-url';
 
-export default defineComponent({
-  components: {
-    Paginator,
-    ListItem,
+const props = defineProps({
+  csrfToken: {
+    type: String,
+    default: '',
   },
-  props: {
-    csrfToken: {
-      type: String,
-      default: '',
-    },
-  },
-  data: () => ({
-    total: 0,
-    items: [] as Item[],
-    currentPage: 1,
-    perPage: 30,
-    cleanupPopStateListener: null as null | (() => void),
-  }),
-  mounted() {
-    const { page, limit } = readPaginationFromUrl(this.perPage);
-    this.perPage = limit;
-    this.currentPage = page;
-    this.cleanupPopStateListener = listenPaginationPopState(this.perPage, ({ page, limit }) => {
-      if (this.currentPage === page && this.perPage === limit) {
-        return;
-      }
-      this.perPage = limit;
-      this.onSearch(page);
+});
+const { csrfToken } = toRefs(props);
+const total = ref(0);
+const items = ref<Item[]>([]);
+const currentPage = ref(1);
+const perPage = ref(30);
+let cleanupPopStateListener: null | (() => void) = null;
+const onSearch = (page: number) => {
+  currentPage.value = page;
+  return axios
+    .get<Response>('/api/notifications', { params: { page, limit: perPage.value } })
+    .then((res) => res.data)
+    .then(({ response: result }) => {
+      total.value = result.total;
+      items.value = result.items;
+      pushPaginationState({ page: currentPage.value, limit: perPage.value });
     });
-    this.onSearch(this.currentPage);
-  },
-  beforeUnmount() {
-    this.cleanupPopStateListener?.();
-    this.cleanupPopStateListener = null;
-  },
-  methods: {
-    onSearch(page: number) {
-      this.currentPage = page;
-      return axios
-        .get<Response>('/api/notifications', { params: { page, limit: this.perPage } })
-        .then((res) => res.data)
-        .then(({ response: { total, items } }) => {
-          this.total = total;
-          this.items = items;
-          pushPaginationState({ page: this.currentPage, limit: this.perPage });
-        });
-    },
-  },
+};
+onMounted(() => {
+  const { page, limit } = readPaginationFromUrl(perPage.value);
+  perPage.value = limit;
+  currentPage.value = page;
+  cleanupPopStateListener = listenPaginationPopState(perPage.value, ({ page, limit }) => {
+    if (currentPage.value === page && perPage.value === limit) {
+      return;
+    }
+    perPage.value = limit;
+    onSearch(page);
+  });
+  onSearch(currentPage.value);
+});
+onBeforeUnmount(() => {
+  cleanupPopStateListener?.();
+  cleanupPopStateListener = null;
 });
 </script>

--- a/resources/assets/scripts/pages/table-templates/index.vue
+++ b/resources/assets/scripts/pages/table-templates/index.vue
@@ -30,9 +30,9 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import axios from 'axios';
-import { defineComponent } from 'vue';
+import { onMounted, onBeforeUnmount, ref, toRefs } from 'vue';
 
 import Paginator from '@/components/Paginator.vue';
 import ListItem from '@/components/table-templates/Item.vue';
@@ -46,53 +46,44 @@ import {
   readPaginationFromUrl,
 } from '@/libs/pagination-url';
 
-export default defineComponent({
-  components: {
-    Paginator,
-    ListItem,
+const props = defineProps({
+  csrfToken: {
+    type: String,
+    default: '',
   },
-  props: {
-    csrfToken: {
-      type: String,
-      default: '',
-    },
-  },
-  data: () => ({
-    total: 0,
-    items: [] as Item[],
-    currentPage: 1,
-    perPage: 30,
-    cleanupPopStateListener: null as null | (() => void),
-  }),
-  mounted() {
-    const { page, limit } = readPaginationFromUrl(this.perPage);
-    this.perPage = limit;
-    this.currentPage = page;
-    this.cleanupPopStateListener = listenPaginationPopState(this.perPage, ({ page, limit }) => {
-      if (this.currentPage === page && this.perPage === limit) {
-        return;
-      }
-      this.perPage = limit;
-      this.onSearch(page);
+});
+const { csrfToken } = toRefs(props);
+const total = ref(0);
+const items = ref<Item[]>([]);
+const currentPage = ref(1);
+const perPage = ref(30);
+let cleanupPopStateListener: null | (() => void) = null;
+const onSearch = (page: number) => {
+  currentPage.value = page;
+  return axios
+    .get<Response>('/api/table-templates', { params: { page, limit: perPage.value } })
+    .then((res) => res.data)
+    .then(({ response: result }) => {
+      total.value = result.total;
+      items.value = result.items;
+      pushPaginationState({ page: currentPage.value, limit: perPage.value });
     });
-    this.onSearch(this.currentPage);
-  },
-  beforeUnmount() {
-    this.cleanupPopStateListener?.();
-    this.cleanupPopStateListener = null;
-  },
-  methods: {
-    onSearch(page: number) {
-      this.currentPage = page;
-      return axios
-        .get<Response>('/api/table-templates', { params: { page, limit: this.perPage } })
-        .then((res) => res.data)
-        .then(({ response: { total, items } }) => {
-          this.total = total;
-          this.items = items;
-          pushPaginationState({ page: this.currentPage, limit: this.perPage });
-        });
-    },
-  },
+};
+onMounted(() => {
+  const { page, limit } = readPaginationFromUrl(perPage.value);
+  perPage.value = limit;
+  currentPage.value = page;
+  cleanupPopStateListener = listenPaginationPopState(perPage.value, ({ page, limit }) => {
+    if (currentPage.value === page && perPage.value === limit) {
+      return;
+    }
+    perPage.value = limit;
+    onSearch(page);
+  });
+  onSearch(currentPage.value);
+});
+onBeforeUnmount(() => {
+  cleanupPopStateListener?.();
+  cleanupPopStateListener = null;
 });
 </script>


### PR DESCRIPTION
## 概要

Vue 3 移行後も残っていた Options API の Vue コンポーネントを Composition API 形式へ移行します。

## 変更内容

- Vue コンポーネントおよびアプリケーションエントリを Composition API へ移行
- `<script setup>` のコンパイラマクロに不要な import を削除
- タイトル情報ページの子コンポーネント名を `<script setup>` の自動解決規則に合わせて修正

## 背景・影響

Options API と Composition API の混在を解消し、Vue コンポーネントの記述形式を統一します。既存の画面操作・API 呼び出し・イベント契約は維持しています。

## 検証

- `npm run lint`
- `npm test -- --run`
- `npm run build`

Closes #1414