### PR TITLE
タイトル成績 CSV アップロードの N+1 クエリを解消

### DIFF
--- a/src/Controller/TitleScoresController.php
+++ b/src/Controller/TitleScoresController.php
@@ -167,6 +167,14 @@ class TitleScoresController extends AppController
                 $player2Name,
                 $player2Division,
             ] = $row;
+            $player1Id = trim($player1Id);
+            $player2Id = trim($player2Id);
+            if (ctype_digit($player1Id)) {
+                $player1Id = (int)$player1Id;
+            }
+            if (ctype_digit($player2Id)) {
+                $player2Id = (int)$player2Id;
+            }
             $rows[] = [
                 'country_id' => $countryId,
                 'name' => $name,
@@ -200,7 +208,7 @@ class TitleScoresController extends AppController
                     ->whereInList('Players.id', array_unique($playerIds))
                     ->all() as $player
             ) {
-                $players[$player->id] = $player;
+                $players[(int)$player->id] = $player;
             }
         }
 

--- a/src/Controller/TitleScoresController.php
+++ b/src/Controller/TitleScoresController.php
@@ -135,7 +135,8 @@ class TitleScoresController extends AppController
             SplFileObject::READ_AHEAD,
         );
 
-        $data = [];
+        $rows = [];
+        $playerIds = [];
         foreach ($csv as $i => $row) {
             // 1行目は無視
             if ($i === 0) {
@@ -166,9 +167,7 @@ class TitleScoresController extends AppController
                 $player2Name,
                 $player2Division,
             ] = $row;
-            // 棋士IDが設定されていればそこから棋士名を埋める
-            // TODO: まとめて取得するなどでクエリ発行回数を改善したい
-            $item = [
+            $rows[] = [
                 'country_id' => $countryId,
                 'name' => $name,
                 'result' => $result,
@@ -176,23 +175,81 @@ class TitleScoresController extends AppController
                 'ended' => str_replace('/', '-', $ended),
                 'is_world' => $isWorld,
                 'is_official' => $isOfficial,
+                'player1_id' => $player1Id,
+                'player1_division' => $player1Division,
+                'player2_id' => $player2Id,
+                'player2_division' => $player2Division,
+            ];
+            if ($player1Id) {
+                $playerIds[] = $player1Id;
+            }
+            if ($player2Id) {
+                $playerIds[] = $player2Id;
+            }
+        }
+
+        if (!$rows) {
+            return $this->renderWithDialogErrors(400, __('Data not exist'));
+        }
+
+        // CSVに含まれる棋士を一括取得し、行処理ではDBへ問い合わせない
+        $players = [];
+        if ($playerIds) {
+            foreach (
+                $this->Players->find()
+                    ->whereInList('Players.id', array_unique($playerIds))
+                    ->all() as $player
+            ) {
+                $players[$player->id] = $player;
+            }
+        }
+
+        $data = [];
+        foreach ($rows as $row) {
+            [
+                'country_id' => $countryId,
+                'name' => $name,
+                'result' => $result,
+                'started' => $started,
+                'ended' => $ended,
+                'is_world' => $isWorld,
+                'is_official' => $isOfficial,
+                'player1_id' => $player1Id,
+                'player1_division' => $player1Division,
+                'player2_id' => $player2Id,
+                'player2_division' => $player2Division,
+            ] = $row;
+
+            $item = [
+                'country_id' => $countryId,
+                'name' => $name,
+                'result' => $result,
+                'started' => $started,
+                'ended' => $ended,
+                'is_world' => $isWorld,
+                'is_official' => $isOfficial,
                 'title_score_details' => [],
             ];
             try {
-                if ($player1Id) {
-                    $player = $this->Players->get($player1Id);
+                foreach (
+                    [
+                        [$player1Id, $player1Division],
+                        [$player2Id, $player2Division],
+                    ] as [$playerId, $division]
+                ) {
+                    if (!$playerId) {
+                        continue;
+                    }
+                    if (!isset($players[$playerId])) {
+                        throw new RecordNotFoundException(sprintf(
+                            'Record not found in table `%s`.',
+                            $this->Players->getTable(),
+                        ));
+                    }
                     $item['title_score_details'][] = [
-                        'player_id' => $player1Id,
-                        'player_name' => $player->name,
-                        'division' => $player1Division,
-                    ];
-                }
-                if ($player2Id) {
-                    $player = $this->Players->get($player2Id);
-                    $item['title_score_details'][] = [
-                        'player_id' => $player2Id,
-                        'player_name' => $player->name,
-                        'division' => $player2Division,
+                        'player_id' => $playerId,
+                        'player_name' => $players[$playerId]->name,
+                        'division' => $division,
                     ];
                 }
             } catch (RecordNotFoundException $e) {
@@ -201,10 +258,6 @@ class TitleScoresController extends AppController
                 return $this->renderWithDialogErrors(400, __('Data not exist'));
             }
             $data[] = $item;
-        }
-
-        if (!$data) {
-            return $this->renderWithDialogErrors(400, __('Data not exist'));
         }
 
         $entities = $this->TitleScores->newEntities($data);

--- a/tests/Fixture/files/title_scores_normalized_ids.csv
+++ b/tests/Fixture/files/title_scores_normalized_ids.csv
@@ -1,0 +1,2 @@
+country_id,started,ended,name,result,is_world,is_official,player1_id,player1_name,player1_division,player2_id,player2_name,player2_division
+1,2023/06/01,2023/06/01,"テスト ID 正規化","白中押勝ち",0,0,001,ユーザ1,勝, 2 ,ユーザ2,敗

--- a/tests/TestCase/Controller/TitleScoresControllerTest.php
+++ b/tests/TestCase/Controller/TitleScoresControllerTest.php
@@ -219,6 +219,30 @@ class TitleScoresControllerTest extends AppTestCase
     }
 
     /**
+     * アップロード成功（棋士IDの表記揺れ）
+     *
+     * @return void
+     */
+    public function testUploadSuccessForNormalizedPlayerIds()
+    {
+        $uploadedFile = $this->createFile('title_scores_normalized_ids.csv', 'text/csv');
+
+        $this->enableCsrfToken();
+        $this->post(['_name' => 'execute_upload_scores'], ['file' => $uploadedFile]);
+        $this->assertResponseSuccess();
+
+        $titleScore = $this->TitleScores->findByStarted('2023-06-01')->first();
+        $this->assertNotNull($titleScore);
+        $playerIds = $this->TitleScoreDetails->find()
+            ->where(['title_score_id' => $titleScore->id])
+            ->orderByAsc('player_id')
+            ->all()
+            ->extract('player_id')
+            ->toList();
+        $this->assertEquals([1, 2], $playerIds);
+    }
+
+    /**
      * 更新失敗
      *
      * @return void


### PR DESCRIPTION
### 概要

タイトル成績 CSV アップロードで、CSV の各行ごとに発行されていた棋士取得クエリを一括取得へ変更します。

### 対応内容

- CSV 内の `player_id` を収集し、重複を除いて対象棋士を一括取得
- 取得した棋士情報を map 化し、行処理では map を参照
- CSV の棋士 ID を trim・整数化してから収集・参照
- 存在しない `player_id` のエラー挙動を従来どおり 400 応答へ維持
- Closes #1590

### 検証

- `docker compose run --rm --no-deps backend composer test`
  - 194 tests / 1024 assertions 成功
  - 既存 PHPUnit deprecation 1件
- `composer cs-check`
- `git diff --check`