### PR TITLE
EntityごとのMass Assignment許可範囲を明示

### DIFF
--- a/src/Controller/PlayerRanksController.php
+++ b/src/Controller/PlayerRanksController.php
@@ -45,6 +45,8 @@ class PlayerRanksController extends AppController
     {
         $data = $this->getRequest()->withData('player_id', $playerId)->getParsedBody();
         $rank = $this->PlayerRanks->newEntity($data);
+        $newest = $data['newest'] ?? false;
+        $rank->newest = is_scalar($newest) && filter_var($newest, FILTER_VALIDATE_BOOLEAN);
 
         // 保存
         if (!$this->PlayerRanks->save($rank)) {

--- a/src/Controller/RetentionHistoriesController.php
+++ b/src/Controller/RetentionHistoriesController.php
@@ -35,9 +35,12 @@ class RetentionHistoriesController extends AppController
     {
         // エンティティ取得 or 生成
         $historyId = $this->getRequest()->getData('id', '');
+        $data = $this->getRequest()->getParsedBody();
         $history = $this->RetentionHistories->findOrNew(['id' => $historyId]);
-        $this->RetentionHistories->patchEntity($history, $this->getRequest()->getParsedBody());
+        $this->RetentionHistories->patchEntity($history, $data);
         $history->title_id = $id;
+        $newest = $data['newest'] ?? false;
+        $history->newest = is_scalar($newest) && filter_var($newest, FILTER_VALIDATE_BOOLEAN);
 
         // 保存
         if (!$this->RetentionHistories->save($history)) {

--- a/src/Controller/TitleScoresController.php
+++ b/src/Controller/TitleScoresController.php
@@ -268,7 +268,13 @@ class TitleScoresController extends AppController
             $data[] = $item;
         }
 
-        $entities = $this->TitleScores->newEntities($data);
+        if (!$data) {
+            return $this->renderWithDialogErrors(400, __('Data not exist'));
+        }
+
+        $entities = $this->TitleScores->newEntities($data, [
+            'accessibleFields' => ['title_score_details' => true],
+        ]);
         if (!$this->TitleScores->saveMany($entities)) {
             return $this->renderWithDialogErrors(400, __('Has errors in uploaded data'));
         }

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -78,7 +78,8 @@ class UsersController extends AppController
         if ($result->isValid()) {
             // 最終ログイン日時を更新
             /** @var \Gotea\Model\Entity\User $user */
-            $user = $this->Users->patchEntity($result->getData(), ['last_logged' => FrozenTime::now()]);
+            $user = $result->getData();
+            $user->last_logged = FrozenTime::now();
             if (!$this->Users->save($user)) {
                 // 仮に保存に失敗してもログ出力のみ行う
                 Log::warning('Update failed: last_logged');

--- a/src/Model/Entity/AppEntity.php
+++ b/src/Model/Entity/AppEntity.php
@@ -20,7 +20,7 @@ class AppEntity extends Entity
      * @var array
      */
     protected array $_accessible = [
-        '*' => true,
+        '*' => false,
         'id' => false,
         'created' => false,
         'modified' => false,

--- a/src/Model/Entity/Country.php
+++ b/src/Model/Entity/Country.php
@@ -21,6 +21,19 @@ use Cake\ORM\TableRegistry;
 class Country extends AppEntity
 {
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'code' => true,
+        'name' => true,
+        'name_english' => true,
+        'has_title' => true,
+        'created' => false,
+        'modified' => false,
+    ];
+
+    /**
      * 棋士の所属組織を取得します。
      *
      * @param mixed $value 値

--- a/src/Model/Entity/Notification.php
+++ b/src/Model/Entity/Notification.php
@@ -24,13 +24,14 @@ class Notification extends AppEntity
      * @inheritDoc
      */
     protected array $_accessible = [
+        'id' => false,
         'title' => true,
         'content' => true,
         'is_draft' => true,
         'published' => true,
         'is_permanent' => true,
-        'created' => true,
-        'modified' => true,
+        'created' => false,
+        'modified' => false,
     ];
 
     /**

--- a/src/Model/Entity/Organization.php
+++ b/src/Model/Entity/Organization.php
@@ -9,4 +9,15 @@ namespace Gotea\Model\Entity;
 class Organization extends AppEntity
 {
     use CountryTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'country_id' => true,
+        'name' => true,
+        'created' => false,
+        'modified' => false,
+    ];
 }

--- a/src/Model/Entity/Player.php
+++ b/src/Model/Entity/Player.php
@@ -52,6 +52,31 @@ class Player extends AppEntity
     use RankTrait;
 
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'country_id' => true,
+        'rank_id' => true,
+        'organization_id' => true,
+        'name' => true,
+        'name_english' => true,
+        'name_other' => true,
+        'sex' => true,
+        'joined_year' => true,
+        'joined_month' => true,
+        'joined_day' => true,
+        'birthday' => true,
+        'remarks' => true,
+        'is_retired' => true,
+        'retired' => true,
+        'created' => false,
+        'created_by' => false,
+        'modified' => false,
+        'modified_by' => false,
+    ];
+
+    /**
      * 引数の日付時点での段位を取得する
      * player_ranks から段位が取得できなかった場合は棋士情報に設定されている段位を返却する
      *

--- a/src/Model/Entity/PlayerRank.php
+++ b/src/Model/Entity/PlayerRank.php
@@ -20,4 +20,16 @@ class PlayerRank extends AppEntity
 {
     use PlayerTrait;
     use RankTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'player_id' => true,
+        'rank_id' => true,
+        'promoted' => true,
+        'created' => false,
+        'modified' => false,
+    ];
 }

--- a/src/Model/Entity/PlayerScore.php
+++ b/src/Model/Entity/PlayerScore.php
@@ -12,6 +12,26 @@ class PlayerScore extends AppEntity
     use RankTrait;
 
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'player_id' => true,
+        'rank_id' => true,
+        'target_year' => true,
+        'win_point' => true,
+        'lose_point' => true,
+        'draw_point' => true,
+        'win_point_world' => true,
+        'lose_point_world' => true,
+        'draw_point_world' => true,
+        'created' => false,
+        'created_by' => false,
+        'modified' => false,
+        'modified_by' => false,
+    ];
+
+    /**
      * ランキング表示用の名前を取得します。
      *
      * @param bool $isWorlds 国際棋戦かどうか

--- a/src/Model/Entity/Rank.php
+++ b/src/Model/Entity/Rank.php
@@ -13,4 +13,14 @@ namespace Gotea\Model\Entity;
  */
 class Rank extends AppEntity
 {
+    /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'name' => true,
+        'rank_numeric' => true,
+        'created' => false,
+        'modified' => false,
+    ];
 }

--- a/src/Model/Entity/RetentionHistory.php
+++ b/src/Model/Entity/RetentionHistory.php
@@ -33,6 +33,26 @@ class RetentionHistory extends AppEntity
     use RankTrait;
 
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'title_id' => true,
+        'player_id' => true,
+        'country_id' => true,
+        'holding' => true,
+        'target_year' => true,
+        'name' => true,
+        'win_group_name' => true,
+        'is_team' => true,
+        'acquired' => true,
+        'is_official' => true,
+        'broadcasted' => true,
+        'created' => false,
+        'modified' => false,
+    ];
+
+    /**
      * タイトル保持者を取得します。
      *
      * @return string

--- a/src/Model/Entity/TableTemplate.php
+++ b/src/Model/Entity/TableTemplate.php
@@ -20,10 +20,11 @@ class TableTemplate extends AppEntity
      * @inheritDoc
      */
     protected array $_accessible = [
+        'id' => false,
         'title' => true,
         'content' => true,
-        'created',
-        'modified' => true,
+        'created' => false,
+        'modified' => false,
     ];
 
     /**

--- a/src/Model/Entity/Title.php
+++ b/src/Model/Entity/Title.php
@@ -38,6 +38,30 @@ class Title extends AppEntity
     use CountryTrait;
 
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'country_id' => true,
+        'name' => true,
+        'name_english' => true,
+        'holding' => true,
+        'sort_order' => true,
+        'html_file_name' => true,
+        'html_file_holding' => true,
+        'html_file_modified' => true,
+        'remarks' => true,
+        'is_team' => true,
+        'is_closed' => true,
+        'is_output' => true,
+        'is_official' => true,
+        'created' => false,
+        'created_by' => false,
+        'modified' => false,
+        'modified_by' => false,
+    ];
+
+    /**
      * 現在の保持情報を取得します。
      *
      * @return \Gotea\Model\Entity\RetentionHistory|null

--- a/src/Model/Entity/TitleScore.php
+++ b/src/Model/Entity/TitleScore.php
@@ -37,6 +37,24 @@ class TitleScore extends AppEntity
     use CountryTrait;
 
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'country_id' => true,
+        'title_id' => true,
+        'name' => true,
+        'result' => true,
+        'started' => true,
+        'ended' => true,
+        'is_world' => true,
+        'is_official' => true,
+        'title_score_details' => false,
+        'created' => false,
+        'modified' => false,
+    ];
+
+    /**
      * 勝者の棋士IDを取得します。
      *
      * @return int|null 勝者の棋士ID

--- a/src/Model/Entity/TitleScoreDetail.php
+++ b/src/Model/Entity/TitleScoreDetail.php
@@ -39,6 +39,19 @@ class TitleScoreDetail extends AppEntity
     use RankTrait;
 
     /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'title_score_id' => true,
+        'player_id' => true,
+        'player_name' => true,
+        'division' => true,
+        'created' => false,
+        'modified' => false,
+    ];
+
+    /**
      * 棋士名と当時の段位を返却します。
      *
      * @param \Cake\I18n\FrozenDate $baseDate 基準となる日付

--- a/src/Model/Entity/UpdatedPoint.php
+++ b/src/Model/Entity/UpdatedPoint.php
@@ -9,4 +9,18 @@ namespace Gotea\Model\Entity;
 class UpdatedPoint extends AppEntity
 {
     use CountryTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected array $_accessible = [
+        'id' => false,
+        'country_id' => true,
+        'target_year' => true,
+        'score_updated' => true,
+        'created' => false,
+        'created_by' => false,
+        'modified' => false,
+        'modified_by' => false,
+    ];
 }

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -23,13 +23,14 @@ class User extends Entity
      * @inheritDoc
      */
     protected array $_accessible = [
+        'id' => false,
         'account' => true,
         'name' => true,
         'password' => true,
-        'is_admin' => true,
-        'last_logged' => true,
-        'created' => true,
-        'modified' => true,
+        'is_admin' => false,
+        'last_logged' => false,
+        'created' => false,
+        'modified' => false,
     ];
 
     /**

--- a/tests/TestCase/Controller/PlayerRanksControllerTest.php
+++ b/tests/TestCase/Controller/PlayerRanksControllerTest.php
@@ -104,6 +104,26 @@ class PlayerRanksControllerTest extends AppTestCase
     }
 
     /**
+     * Test create method with newest flag
+     *
+     * @return void
+     */
+    public function testCreateWithNewest()
+    {
+        $this->enableCsrfToken();
+        $data = [
+            'rank_id' => 4,
+            'promoted' => '2017-12-10',
+            'newest' => '1',
+        ];
+        $this->post(['_name' => 'create_ranks', 1], $data);
+        $this->assertRedirect(['_name' => 'view_player', '?' => ['tab' => 'ranks'], 1]);
+
+        $player = TableRegistry::getTableLocator()->get('Players')->get(1);
+        $this->assertSame(4, $player->rank_id);
+    }
+
+    /**
      * Test update method
      *
      * @return void

--- a/tests/TestCase/Controller/RetentionHistoriesControllerTest.php
+++ b/tests/TestCase/Controller/RetentionHistoriesControllerTest.php
@@ -81,6 +81,31 @@ class RetentionHistoriesControllerTest extends AppTestCase
     }
 
     /**
+     * 保存（最新として登録）
+     *
+     * @return void
+     */
+    public function testSaveWithNewest()
+    {
+        $this->enableCsrfToken();
+        $data = [
+            'player_id' => 1,
+            'title_id' => 1,
+            'name' => 'Test Title',
+            'is_team' => false,
+            'acquired' => '2019-04-01',
+            'holding' => 3,
+            'target_year' => 2017,
+            'newest' => '1',
+        ];
+        $this->post(['_name' => 'save_histories', 1], $data);
+        $this->assertRedirect(['_name' => 'view_title', '?' => ['tab' => 'retention_histories'], 1]);
+
+        $title = TableRegistry::getTableLocator()->get('Titles')->get(1);
+        $this->assertSame(3, $title->holding);
+    }
+
+    /**
      * 保存（更新）
      *
      * @return void

--- a/tests/TestCase/Model/Entity/AccessibleTest.php
+++ b/tests/TestCase/Model/Entity/AccessibleTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace Gotea\Test\TestCase\Model\Entity;
+
+use Cake\TestSuite\TestCase;
+use Gotea\Model\Entity\AppEntity;
+use Gotea\Model\Entity\Country;
+use Gotea\Model\Entity\Notification;
+use Gotea\Model\Entity\Organization;
+use Gotea\Model\Entity\Player;
+use Gotea\Model\Entity\PlayerRank;
+use Gotea\Model\Entity\PlayerScore;
+use Gotea\Model\Entity\Rank;
+use Gotea\Model\Entity\RetentionHistory;
+use Gotea\Model\Entity\TableTemplate;
+use Gotea\Model\Entity\Title;
+use Gotea\Model\Entity\TitleScore;
+use Gotea\Model\Entity\TitleScoreDetail;
+use Gotea\Model\Entity\UpdatedPoint;
+use Gotea\Model\Entity\User;
+
+/**
+ * Entity の mass assignment 設定テスト
+ */
+class AccessibleTest extends TestCase
+{
+    /**
+     * Entity ごとの mass assignment 許可範囲
+     *
+     * @return void
+     */
+    public function testAccessibleFields(): void
+    {
+        $fields = [
+            AppEntity::class => [
+                'allowed' => [],
+                'denied' => ['id', 'created', 'modified', 'newest'],
+            ],
+            Country::class => [
+                'allowed' => ['code', 'name', 'name_english', 'has_title'],
+                'denied' => ['id', 'created', 'modified'],
+            ],
+            Organization::class => [
+                'allowed' => ['country_id', 'name'],
+                'denied' => ['id', 'created', 'modified'],
+            ],
+            Player::class => [
+                'allowed' => [
+                    'country_id', 'rank_id', 'organization_id', 'name',
+                    'name_english', 'name_other', 'sex', 'joined_year',
+                    'joined_month', 'joined_day', 'birthday', 'remarks',
+                    'is_retired', 'retired',
+                ],
+                'denied' => ['id', 'created', 'created_by', 'modified', 'modified_by'],
+            ],
+            PlayerRank::class => [
+                'allowed' => ['player_id', 'rank_id', 'promoted'],
+                'denied' => ['id', 'created', 'modified', 'newest'],
+            ],
+            PlayerScore::class => [
+                'allowed' => [
+                    'player_id', 'rank_id', 'target_year', 'win_point',
+                    'lose_point', 'draw_point', 'win_point_world',
+                    'lose_point_world', 'draw_point_world',
+                ],
+                'denied' => ['id', 'created', 'created_by', 'modified', 'modified_by'],
+            ],
+            Rank::class => [
+                'allowed' => ['name', 'rank_numeric'],
+                'denied' => ['id', 'created', 'modified'],
+            ],
+            RetentionHistory::class => [
+                'allowed' => [
+                    'title_id', 'player_id', 'country_id', 'holding',
+                    'target_year', 'name', 'win_group_name', 'is_team',
+                    'acquired', 'is_official', 'broadcasted',
+                ],
+                'denied' => ['id', 'created', 'modified', 'newest'],
+            ],
+            TableTemplate::class => [
+                'allowed' => ['title', 'content'],
+                'denied' => ['id', 'created', 'modified'],
+            ],
+            Title::class => [
+                'allowed' => [
+                    'country_id', 'name', 'name_english', 'holding',
+                    'sort_order', 'html_file_name', 'html_file_holding',
+                    'html_file_modified', 'remarks', 'is_team', 'is_closed',
+                    'is_output', 'is_official',
+                ],
+                'denied' => ['id', 'created', 'created_by', 'modified', 'modified_by'],
+            ],
+            TitleScore::class => [
+                'allowed' => [
+                    'country_id', 'title_id', 'name', 'result', 'started',
+                    'ended', 'is_world', 'is_official',
+                ],
+                'denied' => ['id', 'created', 'modified', 'title_score_details'],
+            ],
+            TitleScoreDetail::class => [
+                'allowed' => ['title_score_id', 'player_id', 'player_name', 'division'],
+                'denied' => ['id', 'created', 'modified', 'target_year'],
+            ],
+            UpdatedPoint::class => [
+                'allowed' => ['country_id', 'target_year', 'score_updated'],
+                'denied' => ['id', 'created', 'created_by', 'modified', 'modified_by'],
+            ],
+            Notification::class => [
+                'allowed' => [
+                    'title', 'content', 'is_draft', 'published', 'is_permanent',
+                ],
+                'denied' => ['id', 'created', 'modified', 'status'],
+            ],
+            User::class => [
+                'allowed' => ['account', 'name', 'password'],
+                'denied' => ['id', 'is_admin', 'last_logged', 'created', 'modified'],
+            ],
+        ];
+
+        foreach ($fields as $class => $access) {
+            $entity = new $class();
+            foreach ($access['allowed'] as $field) {
+                $this->assertTrue($entity->isAccessible($field), "$class::$field");
+            }
+            foreach ($access['denied'] as $field) {
+                $this->assertFalse($entity->isAccessible($field), "$class::$field");
+            }
+        }
+    }
+}

--- a/tests/TestCase/Model/Table/PlayerRanksTableTest.php
+++ b/tests/TestCase/Model/Table/PlayerRanksTableTest.php
@@ -145,8 +145,8 @@ class PlayerRanksTableTest extends TestCase
             'player_id' => 3,
             'rank_id' => 4,
             'promoted' => '2018-01-03',
-            'newest' => true,
         ]);
+        $rank->newest = true;
 
         $save = $this->PlayerRanks->save($rank, [
             'account' => 'testuser',

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Gotea\Test\TestCase\Model\Table;
 
+use Cake\I18n\FrozenTime;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Gotea\Model\Table\UsersTable;
@@ -144,5 +145,31 @@ class UsersTableTest extends TestCase
         $result = $this->Users->newEntity($params);
         $this->Users->save($result);
         $this->assertNotEmpty($result->getErrors());
+    }
+
+    /**
+     * 管理フラグ・監査項目・最終ログイン日時は mass assignment できない
+     *
+     * @return void
+     */
+    public function testProtectedFieldsAreNotMassAssigned(): void
+    {
+        $entity = $this->Users->newEntity([
+            'account' => 'testuser2',
+            'name' => 'TestUser2',
+            'password' => 'testpassword',
+            'id' => 999,
+            'is_admin' => true,
+            'last_logged' => FrozenTime::now(),
+            'created' => FrozenTime::now(),
+            'modified' => FrozenTime::now(),
+        ]);
+
+        $this->assertSame('testuser2', $entity->account);
+        $this->assertFalse($entity->hasValue('id'));
+        $this->assertFalse($entity->hasValue('is_admin'));
+        $this->assertFalse($entity->hasValue('last_logged'));
+        $this->assertFalse($entity->hasValue('created'));
+        $this->assertFalse($entity->hasValue('modified'));
     }
 }


### PR DESCRIPTION
## 概要

Issue #1587 に対応し、Entity の mass assignment 許可範囲を明示します。

## 変更内容

- 全 Entity の `_accessible` を明示的な許可リストへ変更
- ID、監査項目、管理フラグ、内部制御項目を mass assignment から除外
- `User.last_logged` は直接代入で更新
- CSV 取込時の `title_score_details` だけ、呼び出し側で明示的に許可
- Entity の許可範囲と保護項目の回帰テストを追加

## 検証

- `docker compose exec backend composer test`
- `composer cs-check`

196 tests / 1,174 assertions 成功。

Closes #1587