### PR TITLE
タイトル成績検索の関連取得を高速化

### DIFF
--- a/src/Model/Table/TitleScoresTable.php
+++ b/src/Model/Table/TitleScoresTable.php
@@ -133,10 +133,16 @@ class TitleScoresTable extends AppTable
         $query = $this->find()
             ->contain([
                 'Countries',
-                'TitleScoreDetails',
-                'TitleScoreDetails.Players',
-                'TitleScoreDetails.Players.Ranks',
-                'TitleScoreDetails.Players.PlayerRanks.Ranks',
+                'TitleScoreDetails' => [
+                    'strategy' => 'select',
+                    'Players' => [
+                        'Ranks',
+                        'PlayerRanks' => [
+                            'strategy' => 'select',
+                            'Ranks',
+                        ],
+                    ],
+                ],
             ])
             ->orderByDesc('started')->orderByDesc('TitleScores.id');
 


### PR DESCRIPTION
## 概要

タイトル成績検索で関連データを取得する際の実行計画を改善します。

## 背景

`/scores` でタイトル名（例: `本因坊戦`）を検索すると、MariaDB が `LATERAL DERIVED` を選択し、`PlayerRanks` の取得時にタイトル検索を繰り返し評価して画面が読み込み中のままになることがありました。

## 変更内容

- `TitleScoreDetails` の eager loading を `select` 戦略に変更
- `PlayerRanks` の eager loading を `select` 戦略に変更

ページ対象を確定した後、関連データを `IN` 条件の別クエリで取得するようにしています。

## 検証

- `本因坊戦`（887件）で、関連取得を含む処理が30秒超から約0.35秒に短縮
- タイトル成績・コントローラテスト 22件成功
- PHPコード規約チェック成功

Closes #1634